### PR TITLE
Add support for NVIDIA Thor as iGPU

### DIFF
--- a/pkg/nvlib/info/api.go
+++ b/pkg/nvlib/info/api.go
@@ -30,12 +30,14 @@ type PlatformResolver interface {
 // PropertyExtractor provides a set of functions to query capabilities of the
 // system.
 //
-//go:generate moq -rm -out property-extractor_mock.go . PropertyExtractor
+//go:generate moq  -rm -fmt=goimports -out property-extractor_mock.go . PropertyExtractor
 type PropertyExtractor interface {
 	HasDXCore() (bool, string)
 	HasNvml() (bool, string)
 	HasTegraFiles() (bool, string)
 	// Deprecated: Use HasTegraFiles instead.
 	IsTegraSystem() (bool, string)
+	// Deprecated: Use HasOnlyIntegratedGPUs
 	UsesOnlyNVGPUModule() (bool, string)
+	HasOnlyIntegratedGPUs() (bool, string)
 }

--- a/pkg/nvlib/info/property-extractor_mock.go
+++ b/pkg/nvlib/info/property-extractor_mock.go
@@ -23,6 +23,9 @@ var _ PropertyExtractor = &PropertyExtractorMock{}
 //			HasNvmlFunc: func() (bool, string) {
 //				panic("mock out the HasNvml method")
 //			},
+//			HasOnlyIntegratedGPUsFunc: func() (bool, string) {
+//				panic("mock out the HasOnlyIntegratedGPUs method")
+//			},
 //			HasTegraFilesFunc: func() (bool, string) {
 //				panic("mock out the HasTegraFiles method")
 //			},
@@ -45,6 +48,9 @@ type PropertyExtractorMock struct {
 	// HasNvmlFunc mocks the HasNvml method.
 	HasNvmlFunc func() (bool, string)
 
+	// HasOnlyIntegratedGPUsFunc mocks the HasOnlyIntegratedGPUs method.
+	HasOnlyIntegratedGPUsFunc func() (bool, string)
+
 	// HasTegraFilesFunc mocks the HasTegraFiles method.
 	HasTegraFilesFunc func() (bool, string)
 
@@ -62,6 +68,9 @@ type PropertyExtractorMock struct {
 		// HasNvml holds details about calls to the HasNvml method.
 		HasNvml []struct {
 		}
+		// HasOnlyIntegratedGPUs holds details about calls to the HasOnlyIntegratedGPUs method.
+		HasOnlyIntegratedGPUs []struct {
+		}
 		// HasTegraFiles holds details about calls to the HasTegraFiles method.
 		HasTegraFiles []struct {
 		}
@@ -72,11 +81,12 @@ type PropertyExtractorMock struct {
 		UsesOnlyNVGPUModule []struct {
 		}
 	}
-	lockHasDXCore           sync.RWMutex
-	lockHasNvml             sync.RWMutex
-	lockHasTegraFiles       sync.RWMutex
-	lockIsTegraSystem       sync.RWMutex
-	lockUsesOnlyNVGPUModule sync.RWMutex
+	lockHasDXCore             sync.RWMutex
+	lockHasNvml               sync.RWMutex
+	lockHasOnlyIntegratedGPUs sync.RWMutex
+	lockHasTegraFiles         sync.RWMutex
+	lockIsTegraSystem         sync.RWMutex
+	lockUsesOnlyNVGPUModule   sync.RWMutex
 }
 
 // HasDXCore calls HasDXCoreFunc.
@@ -130,6 +140,33 @@ func (mock *PropertyExtractorMock) HasNvmlCalls() []struct {
 	mock.lockHasNvml.RLock()
 	calls = mock.calls.HasNvml
 	mock.lockHasNvml.RUnlock()
+	return calls
+}
+
+// HasOnlyIntegratedGPUs calls HasOnlyIntegratedGPUsFunc.
+func (mock *PropertyExtractorMock) HasOnlyIntegratedGPUs() (bool, string) {
+	if mock.HasOnlyIntegratedGPUsFunc == nil {
+		panic("PropertyExtractorMock.HasOnlyIntegratedGPUsFunc: method is nil but PropertyExtractor.HasOnlyIntegratedGPUs was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockHasOnlyIntegratedGPUs.Lock()
+	mock.calls.HasOnlyIntegratedGPUs = append(mock.calls.HasOnlyIntegratedGPUs, callInfo)
+	mock.lockHasOnlyIntegratedGPUs.Unlock()
+	return mock.HasOnlyIntegratedGPUsFunc()
+}
+
+// HasOnlyIntegratedGPUsCalls gets all the calls that were made to HasOnlyIntegratedGPUs.
+// Check the length with:
+//
+//	len(mockedPropertyExtractor.HasOnlyIntegratedGPUsCalls())
+func (mock *PropertyExtractorMock) HasOnlyIntegratedGPUsCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockHasOnlyIntegratedGPUs.RLock()
+	calls = mock.calls.HasOnlyIntegratedGPUs
+	mock.lockHasOnlyIntegratedGPUs.RUnlock()
 	return calls
 }
 

--- a/pkg/nvlib/info/resolver.go
+++ b/pkg/nvlib/info/resolver.go
@@ -48,13 +48,13 @@ func (p platformResolver) ResolvePlatform() Platform {
 	hasNVML, reason := p.propertyExtractor.HasNvml()
 	p.logger.Debugf("Is NVML-based system? %v: %v", hasNVML, reason)
 
-	usesOnlyNVGPUModule, reason := p.propertyExtractor.UsesOnlyNVGPUModule()
-	p.logger.Debugf("Uses nvgpu kernel module? %v: %v", usesOnlyNVGPUModule, reason)
+	hasOnlyIntegratedGPUs, reason := p.propertyExtractor.HasOnlyIntegratedGPUs()
+	p.logger.Debugf("Has only integrated GPUs? %v: %v", hasOnlyIntegratedGPUs, reason)
 
 	switch {
 	case hasDXCore:
 		return PlatformWSL
-	case (hasTegraFiles && !hasNVML), usesOnlyNVGPUModule:
+	case (hasTegraFiles && !hasNVML), hasOnlyIntegratedGPUs:
 		return PlatformTegra
 	case hasNVML:
 		return PlatformNVML

--- a/pkg/nvlib/info/resolver_test.go
+++ b/pkg/nvlib/info/resolver_test.go
@@ -25,12 +25,12 @@ import (
 
 func TestResolvePlatform(t *testing.T) {
 	testCases := []struct {
-		platform            string
-		hasTegraFiles       bool
-		hasDXCore           bool
-		hasNVML             bool
-		usesOnlyNVGPUModule bool
-		expected            string
+		platform              string
+		hasTegraFiles         bool
+		hasDXCore             bool
+		hasNVML               bool
+		hasOnlyIntegratedGPUs bool
+		expected              string
 	}{
 		{
 			platform:  "auto",
@@ -59,12 +59,12 @@ func TestResolvePlatform(t *testing.T) {
 			expected:      "nvml",
 		},
 		{
-			platform:            "auto",
-			hasDXCore:           false,
-			hasTegraFiles:       true,
-			hasNVML:             true,
-			usesOnlyNVGPUModule: true,
-			expected:            "tegra",
+			platform:              "auto",
+			hasDXCore:             false,
+			hasTegraFiles:         true,
+			hasNVML:               true,
+			hasOnlyIntegratedGPUs: true,
+			expected:              "tegra",
 		},
 		{
 			platform:      "nvml",
@@ -97,8 +97,8 @@ func TestResolvePlatform(t *testing.T) {
 					HasTegraFilesFunc: func() (bool, string) {
 						return tc.hasTegraFiles, ""
 					},
-					UsesOnlyNVGPUModuleFunc: func() (bool, string) {
-						return tc.usesOnlyNVGPUModule, ""
+					HasOnlyIntegratedGPUsFunc: func() (bool, string) {
+						return tc.hasOnlyIntegratedGPUs, ""
 					},
 				}),
 				WithPlatform(Platform(tc.platform)),


### PR DESCRIPTION
This change add support for NVIDIA Thor as an iGPU / Tegra-based system. To do this, we add a new function to the PropertyExtractor and deprecate the UsesOnlyNVGPUModule function and replace it with a more generic HasOnlyIntegratedGPUs function (since we no longer only look for the `nvgpu` string).