### PR TITLE
Update Device.IsCoherent to only consider ATS mode

### DIFF
--- a/pkg/nvlib/device/device.go
+++ b/pkg/nvlib/device/device.go
@@ -193,13 +193,8 @@ func (d *device) IsCoherent() (bool, error) {
 		return false, fmt.Errorf("error getting addressing mode: %v", ret)
 	}
 
-	switch nvml.DeviceAddressingModeType(mode.Value) {
-	case nvml.DEVICE_ADDRESSING_MODE_HMM:
+	if nvml.DeviceAddressingModeType(mode.Value) == nvml.DEVICE_ADDRESSING_MODE_ATS {
 		return true, nil
-	case nvml.DEVICE_ADDRESSING_MODE_ATS:
-		return true, nil
-	case nvml.DEVICE_ADDRESSING_MODE_NONE:
-		return false, nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
Although the HMM addressing mode supports something close to coherence, this is not true coherence. This change updates the `IsCoherent` utility function to only return true if the addressing mode for a device is ATS.