### PR TITLE
add reuseable composite action for signing into JFrog artifactory

### DIFF
--- a/.github/actions/jfrog-artifactory-action/action.yml
+++ b/.github/actions/jfrog-artifactory-action/action.yml
@@ -1,0 +1,32 @@
+name: 'JFrog Artifactory GOPROXY'
+description: 'Composite GitHub Action which signs into the JFrog Artifactory and retrieves the URL of the Go Module Proxy'
+inputs:
+  artifactory-endpoint:
+    description: "The endpoint for OIDC access to Artifactory instance"
+    required: true
+outputs:
+  goproxy:
+    description: "The URL to the Go module proxy. Set this value to your GOPROXY environment variable"
+    value: ${{ steps.get-goproxy.outputs.goproxy-url }}
+runs:
+  using: "composite"
+  steps:
+    - name: Setup JFrog CLI
+      id: jfrog
+      uses: jfrog/setup-jfrog-cli@v4
+      env:
+        JF_URL: https://${{ inputs.artifactory-endpoint }}/
+      with:
+        oidc-provider-name: nvgithub
+        oidc-audience: ${{ inputs.artifactory-endpoint }}
+    - name: Retrieve the Artifactory GOPROXY
+      id: get-goproxy
+      env:
+        OIDC_USER: ${{ steps.jfrog.outputs.oidc-user }}
+        OIDC_TOKEN: ${{ steps.jfrog.outputs.oidc-token }}
+        OIDC_ARTIFACTORY_ENDPOINT: ${{ inputs.artifactory-endpoint }}
+      run: |
+        OIDC_USER_ENCODED=$(python3 -c 'import urllib.parse, os; print(urllib.parse.quote_plus(os.environ["OIDC_USER"]))')
+        export GOPROXY="https://${OIDC_USER_ENCODED}:${OIDC_TOKEN}@${OIDC_ARTIFACTORY_ENDPOINT}/artifactory/api/go/edge-go-remote-virtual"
+        echo "goproxy-url=$(echo $GOPROXY)" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -77,4 +77,13 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: ${{ env.GOLANG_VERSION }}
-    - run: make build
+
+    - name: JFrog Artifactory
+      id: jfrog-artifactory
+      uses: ./.github/actions/jfrog-artifactory-action
+      with:
+        artifactory-endpoint: ${{ secrets.OIDC_ARTIFACTORY_ENDPOINT }}
+
+    - env:
+        GOPROXY: ${{ steps.jfrog-artifactory.outputs.goproxy-url }}
+      run: make build


### PR DESCRIPTION
This PR adds a composite GitHub action to abstract away the JFrog Artifactory login and GOPROXY url construction in a reusable module.

The intent of this PR is to create a "home" for this compostite GitHub action so that other NVIDIA cloud-native repos may reference this GH action and reuse it