### PR TITLE
Ensure max number of SM are allocated by mig-parted

### DIFF
--- a/pkg/nvlib/device/device.go
+++ b/pkg/nvlib/device/device.go
@@ -373,8 +373,8 @@ func (d *device) VisitMigProfiles(visit func(MigProfile) error) error {
 			return fmt.Errorf("error getting GPU Instance profile info: %v", ret)
 		}
 
-		for j := 0; j < nvml.COMPUTE_INSTANCE_PROFILE_COUNT; j++ {
-			for k := 0; k < nvml.COMPUTE_INSTANCE_ENGINE_PROFILE_COUNT; k++ {
+		for j := nvml.COMPUTE_INSTANCE_PROFILE_COUNT - 1; j >= 0; j-- {
+			for k := nvml.COMPUTE_INSTANCE_ENGINE_PROFILE_COUNT - 1; k >= 0; k-- {
 				p, err := d.lib.NewMigProfile(i, j, k, giProfileInfo.MemorySizeMB, memory.Total)
 				if err != nil {
 					return fmt.Errorf("error creating MIG profile: %v", err)
@@ -394,6 +394,25 @@ func (d *device) VisitMigProfiles(visit func(MigProfile) error) error {
 					continue
 				}
 				if (pi.C < pi.G) && ((pi.C * 2) > (pi.G + 1)) {
+					continue
+				}
+				// NOTE: As we iterate through the profiles by GPU instance count and Compute instance count, we will find revisions
+				// of the COMPUTE_INSTANCE_PROFILE that have the same slice count. In these cases, we need to ensure that we pick the
+				// COMPUTE_INSTANCE_PROFILE with the maximum multiprocessor (SM) count, that is still valid for the GPU instance profile.
+				//
+				// For example: On systems like the H100, the MIG profiles 1g.12gb and 1g.24gb are both supported and will have one cislice.
+				// Given the higher memory capacity, the 1g.24gb profile would be compatible with both the COMPUTE_INSTANCE_PROFILE_1_SLICE
+				// and the COMPUTE_INSTANCE_PROFILE_1_SLICE_REV1. However, the 1g.12gb profile would only be compatible with the
+				// COMPUTE_INSTANCE_PROFILE_1_SLICE. To ensure that we have the CI profile with the maximum compatible SM count, the 1g.12gb
+				// should use the COMPUTE_INSTANCE_PROFILE_1_SLICE and 1g.24gb should use the COMPUTE_INSTANCE_PROFILE_1_SLICE_REV1.
+				//
+				// While iterating through the GPU instance profiles (d.GetGpuInstanceProfileInfo(i)), we need to ensure that we pick the
+				// correct CI profile/revision. For the above example, we will find that GPU_INSTANCE_PROFILE_1_SLICE is only compatible with
+				// COMPUTE_INSTANCE_PROFILE_1_SLICE. The GPU_INSTANCE_PROFILE_1_SLICE_REV2 (when available for systems like the H100) can be
+				// deployed with both COMPUTE_INSTANCE_PROFILE_1_SLICE and COMPUTE_INSTANCE_PROFILE_1_SLICE_REV1, but to maximize performance,
+				// we should pick the COMPUTE_INSTANCE_PROFILE_1_SLICE_REV1 profile. The following check is a temporary workaround to ensure
+				// that we pick the correct COMPUTE_INSTANCE_PROFILE revision.
+				if pi.CIProfileID == nvml.COMPUTE_INSTANCE_PROFILE_1_SLICE_REV1 && pi.GIProfileID != nvml.GPU_INSTANCE_PROFILE_1_SLICE_REV2 {
 					continue
 				}
 


### PR DESCRIPTION
This change is aimed at ensuring that Compute Instance created for a GPU instance are always of correct size. As such it will reverse the order of the loop by which we visit profiles ensuring that higher profile IDs are considered first. With this change we will visit the 1_SLICE_REV1 first (which on some systems can yield a higher performance than 1_SLICE1), then we will iterate down from highest to lower profile ID and match with the first valid profile.

```
for j := nvml.COMPUTE_INSTANCE_PROFILE_COUNT - 1; j >= 0; j-- {
    for k := nvml.COMPUTE_INSTANCE_ENGINE_PROFILE_COUNT - 1; k >= 0; k-- { 
```

Additionally, since we will now be checking for 1_SLICE_REV1 CI profileID before 1_SLICE, we will need to ensure that we are only using it with the compatible GI profileID. When we reverse the order of the loop as shown above, we will be seeing nvml.COMPUTE_INSTANCE_PROFILE_1_SLICE_REV1 before nvml.COMPUTE_INSTANCE_PROFILE_1_SLICE. CI_REV1 can generate a higher number of SMs (matching the expected behavior of nvidia-smi), but it is only compatible with giProfileID nvml.GPU_INSTANCE_PROFILE_1_SLICE_REV2 (if we try using with other GI it errors. This design ensures that we visit CI_REV1 before nvml.COMPUTE_INSTANCE_PROFILE_1_SLICE while also only using with valid GI. Added a check to ensure this:
```
if pi.CIProfileID == nvml.COMPUTE_INSTANCE_PROFILE_1_SLICE_REV1 && pi.GIProfileID != nvml.GPU_INSTANCE_PROFILE_1_SLICE_REV2 {
					continue
				}

```