### PR TITLE
device: add hasSymbol guard to GetAddressingModeAsString

### DIFF
--- a/pkg/nvlib/device/device.go
+++ b/pkg/nvlib/device/device.go
@@ -149,7 +149,11 @@ func (d *device) GetBrandAsString() (string, error) {
 
 // GetAddressingModeAsString returns the Device addressing mode as a string.
 func (d *device) GetAddressingModeAsString() (string, error) {
-	mode, ret := d.GetAddressingMode()
+	if !d.lib.hasSymbol("nvmlDeviceGetAddressingMode") {
+		return "", nil
+	}
+
+	mode, ret := nvml.Device(d).GetAddressingMode()
 
 	switch ret {
 	case nvml.SUCCESS:


### PR DESCRIPTION
While debugging nvidia-dra-driver-gpu on a test cluster running NVIDIA driver 570.148.08, the kubelet-plugin was crashing on startup because GetAddressingModeAsString() calls nvmlDeviceGetAddressingMode without checking whether the symbol exists in the loaded NVML library.

That API was added in NVML v580 (driver 580+), so on older drivers the symbol is absent from libnvml.so. Since the library is opened with RTLD_LAZY, the first call crashes the process.

IsCoherent() already guards against this with hasSymbol(). This applies the same pattern to GetAddressingModeAsString(). Callers now get ("", nil) when the symbol is missing, which is the same result they already get when the symbol is present but returns ERROR_NOT_SUPPORTED.