### PR TITLE
Add SubsystemVendor and SubsystemDevice fields to NvidiaPCIDevice

### DIFF
--- a/pkg/nvpci/mock.go
+++ b/pkg/nvpci/mock.go
@@ -167,6 +167,24 @@ func createNVIDIAgpuFiles(deviceDir string) error {
 		return err
 	}
 
+	subsystemVendor, err := os.Create(filepath.Join(deviceDir, "subsystem_vendor"))
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(subsystemVendor, "0x%x", PCINvidiaVendorID)
+	if err != nil {
+		return err
+	}
+
+	subsystemDevice, err := os.Create(filepath.Join(deviceDir, "subsystem_device"))
+	if err != nil {
+		return err
+	}
+	_, err = subsystemDevice.WriteString("0x16c0")
+	if err != nil {
+		return err
+	}
+
 	_, err = os.Create(filepath.Join(deviceDir, "nvidia"))
 	if err != nil {
 		return err

--- a/pkg/nvpci/nvpci.go
+++ b/pkg/nvpci/nvpci.go
@@ -309,7 +309,9 @@ func (p *nvpci) getNvidiaDeviceByPciBusID(address string, cache map[string]*Nvid
 		if err != nil {
 			return nil, fmt.Errorf("unable to convert subsystem vendor string to uint16: %v", subsystemVendorStr)
 		}
-	case !os.IsNotExist(err):
+	case os.IsNotExist(err):
+		p.logger.Warningf("subsystem_vendor file not found for %s", address)
+	default:
 		return nil, fmt.Errorf("unable to read PCI subsystem vendor id for %s: %v", address, err)
 	}
 
@@ -322,7 +324,9 @@ func (p *nvpci) getNvidiaDeviceByPciBusID(address string, cache map[string]*Nvid
 		if err != nil {
 			return nil, fmt.Errorf("unable to convert subsystem device string to uint16: %v", subsystemDeviceStr)
 		}
-	case !os.IsNotExist(err):
+	case os.IsNotExist(err):
+		p.logger.Warningf("subsystem_device file not found for %s", address)
+	default:
 		return nil, fmt.Errorf("unable to read PCI subsystem device id for %s: %v", address, err)
 	}
 

--- a/pkg/nvpci/nvpci.go
+++ b/pkg/nvpci/nvpci.go
@@ -107,20 +107,22 @@ func (s *SriovInfo) IsVF() bool {
 
 // NvidiaPCIDevice represents a PCI device for an NVIDIA product.
 type NvidiaPCIDevice struct {
-	Path       string
-	Address    string
-	Vendor     uint16
-	Class      uint32
-	ClassName  string
-	Device     uint16
-	DeviceName string
-	Driver     string
-	IommuGroup int
-	IommuFD    string
-	NumaNode   int
-	Config     *ConfigSpace
-	Resources  MemoryResources
-	SriovInfo  SriovInfo
+	Path            string
+	Address         string
+	Vendor          uint16
+	Class           uint32
+	ClassName       string
+	Device          uint16
+	SubsystemVendor uint16
+	SubsystemDevice uint16
+	DeviceName      string
+	Driver          string
+	IommuGroup      int
+	IommuFD         string
+	NumaNode        int
+	Config          *ConfigSpace
+	Resources       MemoryResources
+	SriovInfo       SriovInfo
 }
 
 // IsVGAController if class == 0x300.
@@ -298,6 +300,32 @@ func (p *nvpci) getNvidiaDeviceByPciBusID(address string, cache map[string]*Nvid
 		return nil, fmt.Errorf("unable to convert device string to uint16: %v", deviceStr)
 	}
 
+	var subsystemVendorID uint64
+	subsystemVendor, err := os.ReadFile(path.Join(devicePath, "subsystem_vendor"))
+	switch {
+	case err == nil:
+		subsystemVendorStr := strings.TrimSpace(string(subsystemVendor))
+		subsystemVendorID, err = strconv.ParseUint(subsystemVendorStr, 0, 16)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert subsystem vendor string to uint16: %v", subsystemVendorStr)
+		}
+	case !os.IsNotExist(err):
+		return nil, fmt.Errorf("unable to read PCI subsystem vendor id for %s: %v", address, err)
+	}
+
+	var subsystemDeviceID uint64
+	subsystemDevice, err := os.ReadFile(path.Join(devicePath, "subsystem_device"))
+	switch {
+	case err == nil:
+		subsystemDeviceStr := strings.TrimSpace(string(subsystemDevice))
+		subsystemDeviceID, err = strconv.ParseUint(subsystemDeviceStr, 0, 16)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert subsystem device string to uint16: %v", subsystemDeviceStr)
+		}
+	case !os.IsNotExist(err):
+		return nil, fmt.Errorf("unable to read PCI subsystem device id for %s: %v", address, err)
+	}
+
 	driver, err := getDriver(devicePath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to detect driver for %s: %w", address, err)
@@ -391,20 +419,22 @@ func (p *nvpci) getNvidiaDeviceByPciBusID(address string, cache map[string]*Nvid
 	}
 
 	nvdevice := &NvidiaPCIDevice{
-		Path:       devicePath,
-		Address:    address,
-		Vendor:     uint16(vendorID),
-		Class:      uint32(classID),
-		Device:     uint16(deviceID),
-		Driver:     driver,
-		IommuGroup: int(iommuGroup),
-		IommuFD:    iommuFD,
-		NumaNode:   int(numaNode),
-		Config:     config,
-		Resources:  resources,
-		DeviceName: deviceName,
-		ClassName:  className,
-		SriovInfo:  sriovInfo,
+		Path:            devicePath,
+		Address:         address,
+		Vendor:          uint16(vendorID),
+		Class:           uint32(classID),
+		Device:          uint16(deviceID),
+		SubsystemVendor: uint16(subsystemVendorID),
+		SubsystemDevice: uint16(subsystemDeviceID),
+		Driver:          driver,
+		IommuGroup:      int(iommuGroup),
+		IommuFD:         iommuFD,
+		NumaNode:        int(numaNode),
+		Config:          config,
+		Resources:       resources,
+		DeviceName:      deviceName,
+		ClassName:       className,
+		SriovInfo:       sriovInfo,
 	}
 
 	// Cache physical functions only as VF can't be a root device.

--- a/pkg/nvpci/nvpci_test.go
+++ b/pkg/nvpci/nvpci_test.go
@@ -111,6 +111,63 @@ func TestNvpciSubsystemMissing(t *testing.T) {
 	require.Equal(t, uint16(0), devices[0].SubsystemDevice, "SubsystemDevice should default to 0 when sysfs file is absent")
 }
 
+func TestNvpciSubsystemPartial(t *testing.T) {
+	testCases := []struct {
+		Description     string
+		RemoveFile      string
+		SubsystemVendor uint16
+		SubsystemDevice uint16
+	}{
+		{
+			Description:     "subsystem_vendor missing",
+			RemoveFile:      "subsystem_vendor",
+			SubsystemVendor: 0,
+			SubsystemDevice: 0x16c0,
+		},
+		{
+			Description:     "subsystem_device missing",
+			RemoveFile:      "subsystem_device",
+			SubsystemVendor: 0x10de,
+			SubsystemDevice: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			nvpci, err := NewMockNvpci()
+			require.Nil(t, err, "Error creating NewMockNvpci")
+			defer nvpci.Cleanup()
+
+			err = nvpci.AddMockA100("0000:80:05.1", 0, nil)
+			require.Nil(t, err, "Error adding Mock A100 device to MockNvpci")
+
+			deviceDir := filepath.Join(nvpci.pciDevicesRoot, "0000:80:05.1")
+			require.NoError(t, os.Remove(filepath.Join(deviceDir, tc.RemoveFile)))
+
+			devices, err := nvpci.GetGPUs()
+			require.Nil(t, err, "Error getting GPUs")
+			require.Equal(t, 1, len(devices), "Wrong number of GPU devices")
+			require.Equal(t, tc.SubsystemVendor, devices[0].SubsystemVendor, "Wrong SubsystemVendor for device")
+			require.Equal(t, tc.SubsystemDevice, devices[0].SubsystemDevice, "Wrong SubsystemDevice for device")
+		})
+	}
+}
+
+func TestNvpciSubsystemMalformed(t *testing.T) {
+	nvpci, err := NewMockNvpci()
+	require.Nil(t, err, "Error creating NewMockNvpci")
+	defer nvpci.Cleanup()
+
+	err = nvpci.AddMockA100("0000:80:05.1", 0, nil)
+	require.Nil(t, err, "Error adding Mock A100 device to MockNvpci")
+
+	deviceDir := filepath.Join(nvpci.pciDevicesRoot, "0000:80:05.1")
+	require.NoError(t, os.WriteFile(filepath.Join(deviceDir, "subsystem_vendor"), []byte("notanid"), 0644))
+
+	_, err = nvpci.GetGPUs()
+	require.Error(t, err, "Expected error when subsystem_vendor contents are malformed")
+}
+
 func TestNvpciIOMMUFD(t *testing.T) {
 	testCases := []struct {
 		Description string

--- a/pkg/nvpci/nvpci_test.go
+++ b/pkg/nvpci/nvpci_test.go
@@ -17,6 +17,8 @@
 package nvpci
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -74,6 +76,41 @@ func TestNvpci(t *testing.T) {
 	_, err = nvpci.GetGPUByIndex(1)
 	require.Error(t, err, "No error returned when getting GPU at invalid index")
 }
+
+func TestNvpciSubsystem(t *testing.T) {
+	nvpci, err := NewMockNvpci()
+	require.Nil(t, err, "Error creating NewMockNvpci")
+	defer nvpci.Cleanup()
+
+	err = nvpci.AddMockA100("0000:80:05.1", 0, nil)
+	require.Nil(t, err, "Error adding Mock A100 device to MockNvpci")
+
+	devices, err := nvpci.GetGPUs()
+	require.Nil(t, err, "Error getting GPUs")
+	require.Equal(t, 1, len(devices), "Wrong number of GPU devices")
+	require.Equal(t, uint16(0x10de), devices[0].SubsystemVendor, "Wrong SubsystemVendor for device")
+	require.Equal(t, uint16(0x16c0), devices[0].SubsystemDevice, "Wrong SubsystemDevice for device")
+}
+
+func TestNvpciSubsystemMissing(t *testing.T) {
+	nvpci, err := NewMockNvpci()
+	require.Nil(t, err, "Error creating NewMockNvpci")
+	defer nvpci.Cleanup()
+
+	err = nvpci.AddMockA100("0000:80:05.1", 0, nil)
+	require.Nil(t, err, "Error adding Mock A100 device to MockNvpci")
+
+	deviceDir := filepath.Join(nvpci.pciDevicesRoot, "0000:80:05.1")
+	require.NoError(t, os.Remove(filepath.Join(deviceDir, "subsystem_vendor")))
+	require.NoError(t, os.Remove(filepath.Join(deviceDir, "subsystem_device")))
+
+	devices, err := nvpci.GetGPUs()
+	require.Nil(t, err, "Error getting GPUs")
+	require.Equal(t, 1, len(devices), "Wrong number of GPU devices")
+	require.Equal(t, uint16(0), devices[0].SubsystemVendor, "SubsystemVendor should default to 0 when sysfs file is absent")
+	require.Equal(t, uint16(0), devices[0].SubsystemDevice, "SubsystemDevice should default to 0 when sysfs file is absent")
+}
+
 func TestNvpciIOMMUFD(t *testing.T) {
 	testCases := []struct {
 		Description string


### PR DESCRIPTION
## Description

Adds `SubsystemVendor` and `SubsystemDevice` (`uint16`) to `NvidiaPCIDevice`.

These fields are populated during PCI discovery from:
  - `/sys/bus/pci/devices/<addr>/subsystem_vendor`
  - `/sys/bus/pci/devices/<addr>/subsystem_device`

## Problem

Some NVIDIA devices share the same PCI vendor/device IDs but differ by subsystem IDs. Exposing these fields allows downstream consumers to disambiguate devices during matching/filtering.

Unblocks NVIDIA/mig-parted#343.

## Tested

I added two new tests. 
1) `TestNvpciSubsystem` creates a mock A100 device at 0000:80:05.1, calls `GetGPUs()`, and verifies the new fields are populated from the mock sysfs files:

  ```
SubsystemVendor == 0x10de
  SubsystemDevice == 0x16c0
```

2) `TestNvpciSubsystemMissing` creates the same mock device, then removes the mock `subsystem_vendor` and `subsystem_device` files. It calls `GetGPUs()` and verifies discovery still succeeds, with both new fields left at 0. 
