### PR TITLE
Skip non-regular files in tryResolveLibrary

### DIFF
--- a/pkg/nvlib/info/root.go
+++ b/pkg/nvlib/info/root.go
@@ -18,6 +18,7 @@ package info
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/NVIDIA/go-nvml/pkg/dl"
@@ -66,6 +67,10 @@ func (r root) tryResolveLibrary(libraryName string) string {
 		l := r.join(d, libraryName)
 		resolved, err := resolveLink(l)
 		if err != nil {
+			continue
+		}
+		info, err := os.Stat(resolved)
+		if err != nil || !info.Mode().IsRegular() {
 			continue
 		}
 		return resolved

--- a/pkg/nvlib/info/root_test.go
+++ b/pkg/nvlib/info/root_test.go
@@ -1,0 +1,86 @@
+/**
+# Copyright (c) NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package info
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTryResolveLibrary(t *testing.T) {
+	const libraryName = "libnvidia-ml.so.1"
+
+	testCases := []struct {
+		description string
+		// dirs and files are created relative to the test root before resolving.
+		dirs  []string
+		files []string
+		// expected is the resolved path relative to the test root, or "" if
+		// the input library name is expected to be returned as is.
+		expected string
+	}{
+		{
+			description: "library in first search path",
+			files:       []string{"usr/lib64/" + libraryName},
+			expected:    "usr/lib64/" + libraryName,
+		},
+		{
+			description: "directory in earlier search path does not shadow library",
+			dirs:        []string{"usr/lib64/" + libraryName},
+			files:       []string{"usr/lib/x86_64-linux-gnu/" + libraryName},
+			expected:    "usr/lib/x86_64-linux-gnu/" + libraryName,
+		},
+		{
+			description: "only directories found",
+			dirs:        []string{"usr/lib64/" + libraryName},
+			expected:    "",
+		},
+		{
+			description: "library not found",
+			expected:    "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			testRoot := t.TempDir()
+			for _, d := range tc.dirs {
+				require.NoError(t, os.MkdirAll(filepath.Join(testRoot, d), 0o755))
+			}
+			for _, f := range tc.files {
+				path := filepath.Join(testRoot, f)
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				require.NoError(t, os.WriteFile(path, []byte{}, 0o644))
+			}
+
+			resolved := root(testRoot).tryResolveLibrary(libraryName)
+			if tc.expected == "" {
+				require.Equal(t, libraryName, resolved)
+				return
+			}
+
+			// t.TempDir may itself contain symlinks, so compare against the
+			// resolved expected path.
+			expected, err := filepath.EvalSymlinks(filepath.Join(testRoot, tc.expected))
+			require.NoError(t, err)
+			require.Equal(t, expected, resolved)
+		})
+	}
+}


### PR DESCRIPTION
`tryResolveLibrary` returns the first candidate that `filepath.EvalSymlinks` resolves. `EvalSymlinks` succeeds for anything that exists, directories included, so a stray directory named after the library in an early search path (for example an empty `/usr/lib64/libnvidia-ml.so.1` on an Ubuntu host) shadows the real library in a later one, and the dlopen that follows fails.

With this change, resolution skips any candidate that does not resolve to a regular file and keeps searching, falling back to the documented behavior of returning the library name as is.

The added test covers the shadowing scenario plus the happy path and the fallback paths. The shadowing and directories-only cases fail without the fix.

This is the same bug fixed in kubernetes-sigs/dra-driver-nvidia-gpu#1275, which carries a copy of this discovery code.

Fixes #107