### PR TITLE
update pci.ids to the latest version - 2026.07.31

### DIFF
--- a/pkg/pciids/default_pci.ids
+++ b/pkg/pciids/default_pci.ids
@@ -1,8 +1,8 @@
 #
-#	List of PCI ID's
+#	List of PCI IDs
 #
-#	Version: 2025.07.11
-#	Date:    2025-07-11 03:15:02
+#	Version: 2026.07.31
+#	Date:    2026-07-31 03:15:01
 #
 #	Maintained by Albert Pool, Martin Mares, and other volunteers from
 #	the PCI ID Project at https://pci-ids.ucw.cz/.
@@ -30,49 +30,80 @@
 # This is a relabelled RTL-8139
 	8139  AT-2500TX V3 Ethernet
 0014  Loongson Technology LLC
-	7a00  Hyper Transport Bridge Controller
-	7a02  APB (Advanced Peripheral Bus) Controller
-	7a03  Gigabit Ethernet Controller
-	7a04  OTG USB Controller
-	7a05  Vivante GPU (Graphics Processing Unit)
-	7a06  DC (Display Controller)
-	7a07  HDA (High Definition Audio) Controller
-	7a08  SATA AHCI Controller
-	7a09  PCI-to-PCI Bridge
-	7a0b  SPI Controller
-	7a0c  LPC Controller
-	7a0f  DMA (Direct Memory Access) Controller
-# Found on some boards with two sockets
-	7a10  Hyper Transport Bridge Controller
-	7a13  7A2000 PCH Gigabit Ethernet Controller
-	7a14  EHCI USB Controller
-	7a15  Vivante GPU (Graphics Processing Unit)
-	7a18  SATA 3 AHCI Controller
+	3b0f  DMA Adress Translation Unit [Loongson 3 Processor Family]
+	3c09  Internal PCI to PCI Bridge [Loongson 3 Processor Family]
+	3c0f  DMA Adress Translation Unit [Loongson 3 Processor Family]
+	3c19  PCI Express x16 Root Port [Loongson 3 Processor Family]
+	3c29  PCI Express x8 Root Port [Loongson 3 Processor Family]
+	3c39  PCI Express x4 Root Port [Loongson 3 Processor Family]
+	7a00  7A1000 Chipset Hyper Transport Bridge Controller
+	7a02  2K1000 / 7A1000 Chipset Advanced Peripheral Bus Controller
+	7a03  2K1000/2000 / 7A1000 Chipset Gigabit Ethernet Controller
+	7a04  2K1000 / 7A1000 Chipset OTG USB Controller
+	7a05  2K1000 Vivante GC1000 GPU
+	7a06  2K1000 / 7A1000 Chipset Display Controller
+	7a07  2K1000/2000/3000 / 3B6000M / 7A1000/2000 Chipset HD Audio Controller
+	7a08  2K1000 / 7A1000 Chipset 3Gb/s SATA AHCI Controller
+	7a09  2K1000 / 7A1000 Chipset PCIe x1 Bridge
+	7a0b  7A1000 Chipset SPI Controller
+	7a0c  2K2000 / 7A1000/2000 Chipset LPC Controller
+	7a0e  2K2000 AES Controller
+	7a0f  2K1000 / 7A1000 Chipset DMA Controller
+	7a10  7A2000 Chipset Hyper Transport Bridge Controller
+	7a13  2K2000 / 7A2000 Chipset Gigabit Ethernet Controller
+	7a14  2K1000 / 7A1000/2000 Chipset USB EHCI Controller
+	7a15  7A1000 Chipset Vivante GC1000 GPU
+	7a16  2K1000/2000 VPU Decoder
+	7a17  7A1000 Chipset AC97 Audio Controller
+	7a18  2K2000/3000 / 3B6000M / 7A2000 Chipset 6Gb/s SATA AHCI Controller
 	7a19  PCI-to-PCI Bridge
-	7a1b  SPI Controller
-	7a24  OHCI USB Controller
-# Found on 7A2000 PCH
-	7a25  LG100 GPU
-	7a27  7A2000 PCH I2S Controller
-	7a29  PCI-to-PCI Bridge
-	7a34  xHCI USB Controller
-# Found on 7A2000 PCH
-	7a36  Display Controller
-	7a39  PCIe x1 Root Port
-	7a49  PCIe x4 Root Port
-	7a59  PCIe x8 Root Port
-	7a69  PCIe x16 Root Port
+	7a1a  2K2000 Configuration Bus
+	7a1b  2K2000/3000 / 3B6000M / 7A2000 Chipset SPI Controller
+	7a1d  2K2000 / 2K3000 / 3B6000M RapidIO Interface
+	7a1e  2K2000 DES Controller
+	7a22  2K2000 Advanced Peripheral Bus Controller
+	7a23  Gigabit Ethernet Controller [Chipset / CPU inside]
+	7a24  2K1000 / 7A1000/2000 Chipset USB OHCI Controller
+	7a25  2K2000 / 7A2000 Chipset LG100 GPU
+	7a26  2K1000 Camera Controller
+	7a27  2K2000/3000 / 3B6000M / 7A2000 Chipset I2S Controller
+	7a29  7A1000 Chipset PCIe x8 Bridge
+	7a2e  2K2000 RSA Controller
+	7a2f  2K2000 DMA Controller
+	7a34  2K2000/3000 / 3B6000M / 7A2000 Chipset USB 3.0 xHCI Controller
+	7a35  LG200 GPU
+	7a36  2K2000 / 7A2000 Chipset Display Controller
+	7a37  2K2000/3000 / 3B6000M / 7A2000 Chipset HDMI Audio Controller
+	7a39  2K2000 / 7A2000 Chipset PCIe x1 Root Port
+	7a3e  2K2000 RNG Controller
+	7a42  Advanced Peripheral Bus Controller [Chipset / CPU inside]
+	7a44  2K2000/3000 / 3B6000M USB 2.0 xHCI Controller
+	7a46  Video Display Controller [Chipset / CPU inside]
+	7a47  Pulse-Code Modulation [Chipset / CPU inside]
+	7a48  2K2000/3000 / 3B6000M SDIO Controller
+	7a49  2K2000 / 7A2000 Chipset PCIe x4 Root Port
+	7a54  2K2000 OTG USB Controller
+	7a56  Video Processing Unit Decoder [Chipset / CPU inside]
+	7a59  7A2000 Chipset PCIe x8 Root Port
+	7a66  Video Processing Unit Encoder [Chipset / CPU inside]
+	7a69  7A2000 Chipset PCIe x16 Root Port
+	7a79  2K2000 PCIe Root Complex
+	7a88  2K2000/3000 / 3B6000M eMMC Controller
+	7a89  PCI Express x1 Root Port [Chipset / CPU inside]
+	7a8e  2K2000 SE Controller
+	7a99  PCI Express x4 Root Port [Chipset / CPU inside]
+	7af9  2K2000 PCIe Endpoint
 0018  Fn-Link Technology Limited
 	6252  6252CPUB 802.11ax PCIe Wireless Network Adapter
 001c  PEAK-System Technik GmbH
 	0001  PCAN-PCI CAN-Bus controller
 		001c 0004  2 Channel CAN Bus SJC1000
 		001c 0005  2 Channel CAN Bus SJC1000 (Optically Isolated)
+0029  MICROCHIP
 003d  Lockheed Martin-Marietta Corp
 # Real TJN ID is e159, but they got it wrong several times --mj
 0059  Tiger Jet Network Inc. (Wrong ID)
 0070  Hauppauge computer works Inc.
-	7801  WinTV HVR-1800 MCE
 0071  Nebula Electronics Ltd.
 0095  Silicon Image, Inc. (Wrong ID)
 	0680  Ultra ATA/133 IDE RAID CONTROLLER CARD
@@ -80,6 +111,7 @@
 00a7  Teles AG (Wrong ID)
 0100  nCipher Security
 0123  General Dynamics
+0127  MIPS
 0128  Dell (wrong ID)
 # 018a is not LevelOne but there is a board misprogrammed
 018a  LevelOne
@@ -137,11 +169,14 @@
 0303  Hewlett-Packard Company (Wrong ID)
 0308  ZyXEL Communications Corporation (Wrong ID)
 0315  SK-Electronics Co., Ltd.
+031e  ANDES
 0357  TTTech Computertechnik AG (Wrong ID)
 	000a  TTP-Monitoring Card V2.0
 0432  SCM Microsystems, Inc.
 	0001  Pluto2 DVB-T Receiver for PCMCIA [EasyWatch MobilSet]
+0489  SIFIVE
 0497  Dell Inc. (wrong ID)
+05b7  THEAD
 060e  Lightelligence
 	0001  Hummingbird ES
 0675  Dynalink
@@ -156,6 +191,10 @@
 	0202  GP202
 0721  Sapphire, Inc.
 0731  Jingjia Microelectronics Co Ltd
+	0100  JMN100
+		0731 0101  JMN100 16G
+	1050  JM1050
+		0731 1051  JM1050 8G
 	1100  JM1100
 		0731 1101  JM1100-C
 		0731 1102  JM1100-II
@@ -164,6 +203,11 @@
 		0731 1105  JM1100-Y
 		0731 1106  JM1100-EI
 		0731 1107  JM1100-EM
+		0731 1108  JY1008
+		0731 1109  JY1032
+	1102  JM1100-Y
+		0731 1121  JY1032 LE 64G
+		0731 1122  JY1032 LE 32G
 	7200  JM7200 Series GPU
 		0731 7201  JM7201
 		0731 7202  JM7202
@@ -184,6 +228,7 @@
 		0731 920a  JH920
 		0731 920b  JH920-I
 		0731 920c  JH920-M
+		0731 920d  JH920-II
 	920b  JH920-I
 	920c  JH920-M
 	9210  JM9210
@@ -200,10 +245,17 @@
 		0731 930a  JH930-I
 		0731 930b  JH930-M
 		0731 930c  JH930
+		0731 930d  JH930-II
 	930b  JH930-M
 	f011  JM1100-IV
 	f111  JM1100-MV
 	ff11  JM1100-YV
+		0731 1105  JM11 Series
+		0731 1108  JY1008 vGPU
+		0731 1109  JY1032 vGPU
+		0731 1121  JY1032 LE vGPU
+		0731 1122  JY1032 LE vGPU
+0771  Xi'an Microelectronics Technology Institute
 0777  Ubiquiti Networks, Inc.
 0795  Wired Inc.
 	6663  Butane II (MPEG2 encoder board)
@@ -245,20 +297,8 @@
 		0e11 409b  Smart Array 642
 		0e11 409c  Smart Array 6400
 		0e11 409d  Smart Array 6400 EM
-	0049  NC7132 Gigabit Upgrade Module
-	004a  NC6136 Gigabit Server Adapter
 	005a  Remote Insight II board - Lights-Out
-	007c  NC7770 1000BaseTX
-	007d  NC6770 1000BaseTX
-	0085  NC7780 1000BaseTX
 	00b1  Remote Insight II board - PCI device
-	00bb  NC7760
-	00ca  NC7771
-	00cb  NC7781
-	00cf  NC7772
-	00d0  NC7782
-	00d1  NC7783
-	00e3  NC7761
 	0508  Netelligent 4/16 Token Ring
 	1000  Triflex/Pentium Bridge, Model 1000
 	2000  Triflex/Pentium Bridge, Model 2000
@@ -268,18 +308,10 @@
 	4000  4000 [Triflex]
 	4040  Integrated Array
 	4048  Compaq Raid LC2
-	4050  Smart Array 4200
-	4051  Smart Array 4250ES
-	4058  Smart Array 431
 	4070  Smart Array 5300
 	4080  Smart Array 5i
 	4082  Smart Array 532
 	4083  Smart Array 5312
-	4091  Smart Array 6i
-	409a  Smart Array 641
-	409b  Smart Array 642
-	409c  Smart Array 6400
-	409d  Smart Array 6400 EM
 	6010  HotPlug PCI Bridge 6010
 	7020  USB Controller
 	a0ec  Fibre Channel Host Controller
@@ -312,31 +344,12 @@
 	ae6d  NorthStar CPU to PCI Bridge
 	b011  Netelligent 10/100 TX Embedded UTP
 	b012  Netelligent 10 T/2 PCI UTP/Coax
-	b01e  NC3120 Fast Ethernet NIC
-	b01f  NC3122 Fast Ethernet NIC
-	b02f  NC1120 Ethernet NIC
 	b030  Netelligent 10/100 TX UTP
-	b04a  10/100 TX PCI Intel WOL UTP Controller
 	b060  Smart Array 5300 Controller
-	b0c6  NC3161 Fast Ethernet NIC
-	b0c7  NC3160 Fast Ethernet NIC
-	b0d7  NC3121 Fast Ethernet NIC
-	b0dd  NC3131 Fast Ethernet NIC
-	b0de  NC3132 Fast Ethernet Module
-	b0df  NC6132 Gigabit Module
-	b0e0  NC6133 Gigabit Module
-	b0e1  NC3133 Fast Ethernet Module
-	b123  NC6134 Gigabit NIC
-	b134  NC3163 Fast Ethernet NIC
-	b13c  NC3162 Fast Ethernet NIC
-	b144  NC3123 Fast Ethernet NIC
-	b163  NC3134 Fast Ethernet NIC
-	b164  NC3165 Fast Ethernet Upgrade Module
 	b178  Smart Array 5i/532
 		0e11 4080  Smart Array 5i
 		0e11 4082  Smart Array 532
 		0e11 4083  Smart Array 5312
-	b1a4  NC7131 Gigabit Server Adapter
 	b200  Memory Hot-Plug Controller
 	b203  Integrated Lights Out Controller
 		103c 3305  iLO2
@@ -346,6 +359,9 @@
 	f130  NetFlex-3/P ThunderLAN 1.0
 	f150  NetFlex-3/P ThunderLAN 2.3
 0e55  HaSoTec GmbH
+# Real MediaTek ID is 0x14c3, this actually the USB VID and was used on at least the MT7621
+0e8d  MediaTek Inc. (Wrong ID)
+	0801  MT7621 PCIe Bridge
 0eac  SHF Communication Technologies AG
 	0008  Ethernet Powerlink Managing Node 01
 0f62  Acrox Technologies Co., Ltd.
@@ -540,7 +556,7 @@
 		1028 1f35  PERC H710 Adapter
 		1028 1f37  PERC H710 Mini (for blades)
 		1028 1f38  PERC H710 Mini (for monolithics)
-		15d9 0690  LSI MegaRAID ROMB
+		15d9 0690  AOC-S2208L-H8iR
 		8086 3510  RMS25PB080 RAID Controller
 		8086 3511  RMS25PB040 RAID Controller
 		8086 3512  RMT3PB080 RAID Controller
@@ -640,8 +656,10 @@
 	0072  SAS2008 PCI-Express Fusion-MPT SAS-2 [Falcon]
 		1000 3020  9211-8i
 		1000 3040  9210-8i
+		1000 3060  9212-4i4e
 		1000 3080  9200-8e [LSI SAS 6Gb/s SAS/SATA PCIe x8 External HBA]
 		1000 30b0  9200-8e [LSI SAS 6Gb/s SAS/SATA PCIe x8 External HBA]
+		1000 30e0  9202-16e
 		1014 03ca  IBM 6Gb SAS HBA [9212-4i4e]
 		1028 1f1c  6Gbps SAS HBA Adapter
 		1028 1f1d  PERC H200 Adapter
@@ -760,6 +778,7 @@
 		1000 3040  9207-8e SAS2.1 HBA
 		1000 3050  SAS9217-8i
 		1000 3060  SAS9217-4i4e
+		1000 3070  SAS9206-16e
 		1014 0472  N2125 External Host Bus Adapter
 		1014 047a  N2115 Internal Host Bus Adapter
 		1590 0041  H220i
@@ -783,6 +802,7 @@
 	0094  SAS3108 PCI-Express Fusion-MPT SAS-3
 	0095  SAS3108 PCI-Express Fusion-MPT SAS-3
 	0096  SAS3004 PCI-Express Fusion-MPT SAS-3
+		1000 3110  SAS9300-4i
 	0097  SAS3008 PCI-Express Fusion-MPT SAS-3
 		1000 3090  SAS9311-8i
 		1000 30a0  SAS9300-8e
@@ -843,7 +863,9 @@
 		15d9 1d03  AOC-S4116L-H16IR (16DD/96DD) RAID Adapter
 		15d9 1d07  AOC-S4016L-L16IT Storage Adapter
 		15d9 1d08  AOC-S4016L-L16IR Storage Adapter
+		17aa 7855  ThinkSystem RAID 950W-16i 8GB Flash PCIe Gen4 24Gb Adapter
 		1d49 020a  ThinkSystem 450W-16e SAS/SATA PCIe Gen4 24Gb HBA
+		1d49 020c  ThinkSystem 450W-16e PCIe Gen4 HBA
 	00ab  SAS3516 Fusion-MPT Tri-Mode RAID On Chip (ROC)
 # 8 Internal and 8 External port channel 9400 HBA
 		1000 3040  HBA 9400-8i8e
@@ -868,6 +890,7 @@
 		1d49 0202  ThinkSystem 430-8e SAS/SATA 12Gb HBA
 		1d49 0204  ThinkSystem 430-8i SAS/SATA 12Gb Dense HBA
 	00b2  PCIe Switch management endpoint
+		15d9 1d24  AOM-PCIE5-418P
 		1d49 0003  ThinkSystem 1611-8P PCIe Gen4 NVMe Switch Adapter
 # 24G SAS/PCIe storage adapter chip
 	00b3  Fusion-MPT 24G SAS/PCIe SAS50xx/SAS51xx
@@ -888,7 +911,9 @@
 		1028 23cb  PERC H975i Front
 		1028 23cd  PERC H975i Adapter
 		1028 2446  PERC H976i Front
+		17aa 784c  ThinkSystem RAID 960W PCIe Gen5 Adapter
 		1d49 020b  ThinkSystem 460-16e SAS/SATA PCIe Gen5 24Gb HBA
+	00b4  Fusion-MPT 24G SAS/PCIe SAS50xx/SAS51xx
 	00b5  Fusion-MPT 24G SAS/PCIe SAS50xx/SAS51xx
 # 9760W 32 internal port RAID controller
 		1000 5000  MegaRAID 9760W-32i 24G SAS/PCIe Storage Adapter
@@ -906,6 +931,14 @@
 		1028 22d3  PERC H975i Adapter - Virtual
 		1028 23cb  PERC H975i Front - Virtual
 		1028 23cd  PERC H975i Adapter - Virtual
+		17aa 784c  ThinkSystem RAID 960W PCIe Gen5 Adapter
+	00b6  Fusion-MPT 24G SAS/PCIe SAS50xx/SAS51xx
+		1000 5000  MegaRAID 9760W-32i 24G SAS/PCIe Storage Adapter
+		1000 5001  MegaRAID 9760W-16i 24G SAS/PCIe Storage Adapter
+		1000 5010  MegaRAID 9760W-16i16e 24G SAS/PCIe Storage Adapter
+		1000 5020  eHBA 9700W-32i 24G SAS/PCIe Storage Adapter
+		1000 5021  eHBA 9700W-16i 24G SAS/PCIe Storage Adapter
+		1000 5030  eHBA 9700-16e 24G SAS/PCIe Storage Adapter
 		1028 2446  PERC H976i Front - Virtual
 # Broadcom next-gen MPT PCIe switch
 	00b8  Fusion-MPT Switch SAS50xx/SAS51xx
@@ -920,6 +953,7 @@
 		1000 3190  SAS9305-16i
 # SAS 9305 24 internal port HBA
 		1000 31a0  SAS9305-24i
+		1000 31b0  SAS9306-24i
 		1170 0002  SAS3224 PCI Express to 12Gb HBA MEZZ CARD
 	00c5  SAS3316 PCI-Express Fusion-MPT SAS-3
 	00c6  SAS3316 PCI-Express Fusion-MPT SAS-3
@@ -1157,11 +1191,15 @@
 		1d49 0505  ThinkSystem RAID 540-8i PCIe Gen4 12Gb Adapter
 		1d49 0506  ThinkSystem RAID 540-16i PCIe Gen4 12Gb Adapter
 		1d49 0507  ThinkSystem RAID 545-8i PCIe Gen4 12Gb Adapter
+		1d49 0508  ThinkSystem RAID 545-8i PCIe Gen4 12Gb Internal Adapter
 		1d49 0700  ThinkSystem M.2 RAID B540i-2i SATA/NVMe Enablement Kit
 		1d49 0701  ThinkSystem 7mm RAID B540p-2HS SATA/NVMe Enablement Kit
 		1d49 0702  ThinkSystem M.2 RAID B540p-2HS SATA/NVMe Enablement Kit
 		1d49 0703  ThinkSystem M.2 RAID B540d-2HS SATA/NVMe Enablement Kit
 		1d49 0704  ThinkSystem M.2 RAID B545i-2i SATA/NVMe Enablement Kit
+		1d49 0705  ThinkSystem M.2 RAID B550p-2HS SATA/NVMe Enablement Kit
+		1d49 0706  ThinkSystem M.2 RAID B550d-2HS SATA/NVMe Enablement Kit
+		1d49 0707  ThinkSystem M.2 RAID B550i-2i SATA/NVMe Enablement Kit
 	10e7  MegaRAID 12GSAS/PCIe Unsupported SAS38xx
 	1960  MegaRAID
 		1000 0518  MegaRAID 518 SCSI 320-2 Controller
@@ -1220,6 +1258,7 @@
 		1000 100b  PEX89000 PCIe Gen 5 Virtual Upstream/Downstream Port
 		1000 2004  PEX89000 Virtual PCIe TWC/NT 2.0 Endpoint
 		1000 2005  PEX89000 Virtual PCIe gDMA Endpoint
+		15d9 1d24  AOM-PCIE5-418P
 # Lower lane count PEX89000 switch
 	c034  PEX890xx PCIe Gen 5 Switch
 # Lower lane count PEX89000 switch
@@ -1233,6 +1272,7 @@
 		1000 2004  PEX89000 Virtual PCIe TWC/NT 2.0 Endpoint
 # Lower lane count PEX89000 switch
 		1000 2005  PEX89000 Virtual PCIe gDMA Endpoint
+	c040  PEX90xxx PCIe Gen 6 Switch
 1001  Kolter Electronic
 	0010  PCI 1616 Measurement card with 32 digital I/O lines
 	0011  OPTO-PCI Opto-Isolated digital I/O board
@@ -1274,15 +1314,21 @@
 	131c  Kaveri [Radeon R7 Graphics]
 	131d  Kaveri [Radeon R6 Graphics]
 	13c0  Granite Ridge [Radeon Graphics]
+# Used in the Sony PlayStation 5 Phat
+	13db  Cyan Skillfish [PlayStation 5 APU]
 	13e9  Ariel/Navi10Lite
+	13ea  Cyan Skillfish HDMI/DP Audio Controller
 	13f9  Oberon/Navi12Lite
+# Confirmed on PS5 Phat CFI-1016B; see also 13db
+	13fb  Cyan Skillfish [PlayStation 5 APU]
 	13fe  Cyan Skillfish [BC-250]
 # Used in the Steam Deck OLED
 	1435  Sephiroth [AMD Custom GPU 0405]
 	145a  Dummy Function (absent graphics controller)
 	1478  Navi 10 XL Upstream Port of PCI Express Switch
 	1479  Navi 10 XL Downstream Port of PCI Express Switch
-	1506  Mendocino
+	1506  Mendocino [Radeon 610M]
+		17aa 380e  IdeaPad 1 15AMN7
 	150e  Strix [Radeon 880M / 890M]
 	154c  Kryptos [Radeon RX 350]
 		1462 7c28  MS-7C28 Motherboard
@@ -1291,6 +1337,7 @@
 	1552  Pooky
 	1561  Anubis
 	1586  Strix Halo [Radeon Graphics / Radeon 8050S Graphics / Radeon 8060S Graphics]
+	15b3  Stoney HDMI/DP Audio Controller
 	15bf  Phoenix1
 	15c8  Phoenix2
 	15d8  Picasso/Raven 2 [Radeon Vega Series / Radeon Vega Mobile Series]
@@ -1322,7 +1369,7 @@
 		1043 16c2  Radeon Vega 8
 # Used in the Steam Deck LCD
 	163f  VanGogh [AMD Custom GPU 0405]
-	1640  Radeon High Definition Audio Controller [Rembrandt/Strix]
+	1640  Radeon High Definition Audio Controller
 	164c  Lucienne
 	164d  Rembrandt
 	164e  Raphael
@@ -2290,7 +2337,7 @@
 		1642 3c81  Radeon HD 8670
 		1642 3c91  Radeon HD 8670
 		1642 3f09  Radeon R7 350
-	6611  Oland [Radeon HD 8570 / R5 430 OEM / R7 240/340 / Radeon 520 OEM]
+	6611  Oland [Radeon HD 8570 / R5 430 OEM / R7 240/340/430 / Radeon 520 OEM]
 		1028 1001  Radeon R5 430 OEM (1024 MByte)
 		1028 1002  Radeon R5 430 OEM (2048 MByte)
 # The 'AMD Radeon R5 430' instead of 240/340 is NOT a typo! It's actually correct.
@@ -2298,6 +2345,7 @@
 		1028 210b  Radeon R5 240 OEM
 # OEM-card for Dell; verified through AMD's own drivers (*.inf) and a TPU BIOS in database
 		1028 2121  Radeon HD 8570 OEM
+		103c 3375  Radeon R7 430 OEM
 # OEM-card from Fujitsu; verified through AMD's own drivers (*.inf)
 		10cf 1889  Radeon HD 8570 OEM
 		1642 1869  Radeon 520 OEM
@@ -2377,7 +2425,7 @@
 	6667  Jet ULT [Radeon R5 M230]
 	666f  Sun LE [Radeon HD 8550M / R5 M230]
 	66a0  Vega 20 [Radeon Pro/Radeon Instinct]
-	66a1  Vega 20 [Radeon Pro VII/Radeon Instinct MI50 32GB]
+	66a1  Vega 20 [Radeon Pro VII/Radeon Instinct MI50]
 	66a2  Vega 20
 	66a3  Vega 20 [Radeon Pro Vega II/Radeon Pro Vega II Duo]
 	66a7  Vega 20 [Radeon Pro Vega 20]
@@ -3849,6 +3897,7 @@
 	6995  Lexa XT [Radeon PRO WX 2100]
 	699f  Lexa PRO [Radeon 540/540X/550/550X / RX 540X/550/550X]
 		1028 1720  Radeon RX 550X
+		1458 22f3  Radeon RX 550 2GB
 		148c 2380  Lexa XL [Radeon RX 550]
 		17aa 5069  Thinkpad E480/E580
 		1da2 e367  Lexa PRO [Radeon RX 550]
@@ -4012,6 +4061,7 @@
 		1002 0b36  Reference RX 5700 XT
 		1458 2313  Radeon RX 5700 XT Gaming OC
 		1458 231d  Radeon RX 5600 XT/REV 2.0 [Windforce 6GB OC]
+		1462 381e  RX 5600 XT MECH OC
 		148c 2398  AXRX 5700 XT 8GBD6-3DHE/OC [PowerColor Red Devil Radeon RX 5700 XT]
 		1682 5701  RX 5700 XT RAW II
 		1849 5102  RX5700 CLD 8GO [ASRock Challenger D RX 5700 OC]
@@ -4019,8 +4069,9 @@
 		1da2 e409  Sapphire Technology Limited Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]
 		1da2 e410  Sapphire NITRO+ RX 5700 XT
 		1da2 e411  Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]
-	7340  Navi 14 [Radeon RX 5500/5500M / Pro 5500M]
-		106b 0210  Radeon Pro 5300M
+	7340  Navi 14 [Radeon RX 5500/5500M / Pro 5300/5300M/5500M]
+		106b 0210  MacBookPro16,1 (16", 2019) [Radeon Pro 5300M]
+		106b 0219  iMac (Retina 5K, 27-inch, 2020) [Radeon Pro 5300]
 	7341  Navi 14 [Radeon Pro W5500]
 	7347  Navi 14 [Radeon Pro W5500M]
 	734f  Navi 14 [Radeon Pro W5300M]
@@ -4056,6 +4107,7 @@
 	73c4  Navi 22 USB
 	73ce  Navi 22-XL SRIOV MxGPU
 	73df  Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]
+		1002 0e36  Radeon RX 6700 XT 12G
 		1043 16c2  Radeon RX 6800M
 		1458 2408  Radeon RX 6750 XT GAMING OC 12G
 		1462 3980  Radeon RX 6700 XT Mech 2X 12G [MSI]
@@ -4097,7 +4149,9 @@
 		1da2 e457  PULSE AMD Radeon RX 6500 XT
 	7446  Navi 31 USB
 	7448  Navi 31 [Radeon Pro W7900]
+	7449  Navi 31 [Radeon Pro W7800 48GB]
 	744a  Navi 31 [Radeon Pro W7900 Dual Slot]
+	744b  Navi 31 [Radeon Pro W7900D]
 	744c  Navi 31 [Radeon RX 7900 XT/7900 XTX/7900 GRE/7900M]
 		1002 0e3b  RX 7900 XTX / RX 7900 GRE [XFX]
 		1043 0506  TUF Gaming Radeon RX 7900 XTX OC
@@ -4109,10 +4163,11 @@
 		1eae 7901  RX-79XMERCB9 [SPEEDSTER MERC 310 RX 7900 XTX]
 		1eae 790a  RX-79GMERCBR [XFX RX 7900 GRE]
 	745e  Navi 31 [Radeon Pro W7800]
-	7460  Navi32 GL-XL [AMD Radeon PRO V710]
+	7460  Navi 32 GL-XL [AMD Radeon PRO V710]
 	7461  Navi 32 [AMD Radeon PRO V710]
 	7470  Navi 32 [Radeon PRO W7700]
 	747e  Navi 32 [Radeon RX 7700 XT / 7800 XT]
+		1462 7e26  Radeon RX 7800 XT [Nitro+]
 		148c 2427  RX 7800 XT [Hellhound / Red Devil]
 	7480  Navi 33 [Radeon RX 7600/7600 XT/7600M XT/7600S/7700S / PRO W7600]
 		1849 5313  RX 7600 Challenger OC
@@ -4132,10 +4187,19 @@
 	74b9  Aqua Vanjaram [Instinct MI325X VF]
 	74bd  Aqua Vanjaram [Instinct MI300X HF]
 	7550  Navi 48 [Radeon RX 9070/9070 XT/9070 GRE]
-		148c 2435  Reaper Radeon RX 9070 XT 16GB GDDR6 (RX9070XT 16G-A)
+		1458 2437  Navi 48 XTX [Radeon RX 9070 XT Gaming OC ICE 16G]
+		148c 2435  Radeon RX 9070 XT 16GB
+		1849 5403  Navi 48 XTX [Steel Legend Radeon RX 9070 XT]
 		1da2 e490  Navi 48 XTX [Sapphire Pulse Radeon RX 9070 XT]
 	7551  Navi 48 [Radeon AI PRO R9700]
 	7590  Navi 44 [Radeon RX 9060 XT]
+# ASUS RX 9060 XT 16GB
+		1043 0639  Navi 44 [Radeon RX 9060 XT]
+		1458 2429  GV-R9060XTGAMING OC-16GD [Radeon RX 9060 XT GAMING OC 16G]
+		1eae 8601  RX-96TS316W7 [SWIFT RX 9060 XT OC White Triple Fan Gaming Edition 16GB]
+	75a0  Aqua Vanjaram [Instinct MI350X]
+	75a3  Aqua Vanjaram [Instinct MI355X]
+	75a8  Aqua Vanjaram [Instinct MI350P]
 	7833  RS350 Host Bridge
 	7834  RS350 [Radeon 9100 PRO/XT IGP]
 	7835  RS350M [Mobility Radeon 9000 IGP]
@@ -4243,6 +4307,7 @@
 	9500  RV670 [Radeon HD 3850 X2]
 	9501  RV670 [Radeon HD 3870]
 		174b e620  Radeon HD 3870
+		1787 2244  Radeon HD 3870
 	9504  RV670/M88 [Mobility Radeon HD 3850]
 	9505  RV670 [Radeon HD 3690/3850]
 		148c 3000  Radeon HD 3850
@@ -4894,6 +4959,7 @@
 	0144  Yotta Video Compositor Output
 		1014 0145  Yotta Output Controller (ytout)
 	0156  405GP PLB to PCI Bridge
+		1fc3 0004  IC695ETM001 RX3i Ethernet PCI Module
 	015e  622Mbps ATM PCI Adapter
 	0160  64bit/66MHz PCI ATM 155 MMF
 	016e  GXT4000P Graphics Adapter
@@ -5472,7 +5538,7 @@
 	15e2  Audio Coprocessor
 		17aa 5124  ThinkPad E595
 		ea50 ce19  mCOM10-L1900
-	15e3  Family 17h/19h/1ah HD Audio Controller
+	15e3  Ryzen HD Audio Controller
 		103c 8615  Pavilion Laptop 15-cw1xxx
 		103c 8b17  ProBook 445 G9/455 G9
 		1043 86c7  PRIME B450M-A Motherboard
@@ -6237,6 +6303,7 @@
 	0534  G200eR2
 		1028 04f7  PowerEdge R320 server
 	0536  Integrated Matrox G200eW3 Graphics Controller
+		1028 0a6b  PowerEdge R760
 	0538  MGA G200eH3
 		1590 00e4  iLO5 VGA
 	0540  M91XX
@@ -6418,6 +6485,7 @@
 	01b4  Celleb platform IDE interface
 	01b5  SCC USB 2.0 EHCI controller
 	01b6  SCC USB 1.1 OHCI controller
+	01ba  SpursEngine SE1000 accelerator
 1030  TMC Research
 1031  Miro Computer Products AG
 	5601  DC20 ASIC
@@ -6447,6 +6515,7 @@
 		1033 0035  USB Controller
 		103c 1293  USB add-in card
 		103c 1294  USB 2.0 add-in card
+		1154 0207  Buffalo IFC-USB2P4
 		1179 0001  USB
 		1186 0035  DUB-C2 USB 2.0 2-port 32-bit cardbus controller
 		12ee 7000  Root Hub
@@ -6481,6 +6550,7 @@
 	00ce  uPD72871 [Firewarden] IEEE1394a OHCI 1.0 Link/1-port PHY Controller
 	00df  Vr4131
 	00e0  uPD72010x USB 2.0 Controller
+		1154 0208  Buffalo IFC-USB2P4
 		1186 f100  DUB-C2 USB 2.0 2-port 32-bit cardbus controller
 		12ee 7001  Root hub
 		14c2 0205  PTI-205N USB 2.0 Host Controller
@@ -6493,6 +6563,7 @@
 	010c  VR7701
 	0125  uPD720400 PCI Express - PCI/PCI-X Bridge
 	013a  Dual Tuner/MPEG Encoder
+	0165  uPD61253F1 MPEG Video Broadcast Decoder
 	0194  uPD720200 USB 3.0 Host Controller
 		1028 04a3  Precision M4600
 		1028 04b2  Vostro 3350
@@ -7148,9 +7219,12 @@
 	8241  TUSB73x0 SuperSpeed USB 3.0 xHCI Host Controller
 		1014 04b2  S824 (8286-42A)
 	8400  ACX 100 22Mbps Wireless Interface
+		111a 1021  SpeedStream 1021 (SS1021) Wireless Cardbus PC Card
 		1186 3b00  DWL-650+ PC Card cardbus 22Mbs Wireless Adapter [AirPlus]
 		1186 3b01  DWL-520+ 22Mbps PCI Wireless Adapter
 		1395 2201  WL22-PC
+		167d b230  Netopia TER/WPC11N1 Wireless LAN Card
+		16a5 1801  WE302-TF
 		16ab 8501  WL-8305 IEEE802.11b+ Wireless LAN PCI Adapter
 	8401  ACX 100 22Mbps Wireless Interface
 	8888  Multicore DSP+ARM KeyStone II SOC
@@ -7163,12 +7237,15 @@
 # Found in Philips ADSL ANNEX A WLAN Router SNA6500/18 sold by Belgacom
 		104c 9067  TNETW1130GVF
 		104c 9096  Trendnet TEW-412PC Wireless PCI Adapter (Version A)
+		1154 032c  WLI-CB-G54L
 		1186 3b04  DWL-G520+ Wireless PCI Adapter
 		1186 3b05  DWL-G650+ AirPlusG+ CardBus Wireless LAN
 		1186 3b08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.B1)
 		1385 4c00  WG311v2 802.11g Wireless PCI Adapter
 		13d1 aba0  SWLMP-54108 108Mbps Wireless mini PCI card 802.11g+
 		14ea ab07  GW-NS54GM Wireless Cardbus Adapter
+		167d b260  SWL-2600N
+		16ab 9067  A90-200WG-01 802.11g Wireless PC Card
 		16ec 010d  USR5416 802.11g Wireless Turbo PCI Adapter
 		16ec 010e  USR5410 802.11g Wireless Cardbus Adapter
 		1737 0033  WPC54G v2 802.11g Wireless-G Notebook Adapter
@@ -7268,6 +7345,7 @@
 	ac8f  PCI7420/7620 SD/MS-Pro Controller
 		1028 018d  Inspiron 700m/710m
 	b001  TMS320C6424
+	b012  TDA4VH PCIE Root Complex
 	fe00  FireWire Host Controller
 	fe03  12C01A FireWire Host Controller
 104d  Sony Corporation
@@ -7319,6 +7397,12 @@
 	90dd  Baikal Memory (DDR3/SPM)
 	90de  Baikal USB 3.0 xHCI Host Controller
 	90eb  CXD90062GG
+	90ec  Salina PCIe Controller
+	9104  Salina Ethernet Controller
+	9105  Salina SATA AHCI Controller
+	9106  Salina SATA AHCI Controller (secondary)
+	9107  Salina PCIe Glue and Miscellaneous Devices
+	9108  Salina USB xHCI Host Controller
 	9121  Nextorage NEM-PA NVMe SSD for PlayStation
 104e  Oak Technology, Inc
 	0017  OTI-64017
@@ -7439,8 +7523,7 @@
 	4802  Falcon
 	4803  Hawk
 	4806  CPX8216
-# MPC7410 PowerPC microprocessor and PCI host bridge
-	480b  MPC7410
+	480b  Harrier PCI Host Bridge
 	4d68  20268
 	5600  SM56 PCI Modem
 		1057 0300  SM56 PCI Speakerphone Modem
@@ -7554,7 +7637,37 @@
 	e350  80333 [SuperTrak EX24350]
 105b  Foxconn International, Inc.
 	9602  RS780/RS880 PCI to PCI bridge (int gfx)
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0ab  T99W175 5G Modem [Snapdragon X55]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0b0  DW5930e 5G Modem [Snapdragon X55]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0b1  DW5930e 5G Modem [Snapdragon X55]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0bf  T99W175 5G Modem [Snapdragon X55]
 	e0c3  T99W175 5G Modem [Snapdragon X55]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0d8  T99W368 5G Modem [Snapdragon X65]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0d9  T99W373 5G Modem [Snapdragon X62]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0f0  T99W510 4G Modem [Snapdragon X24]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0f1  T99W510 4G Modem [Snapdragon X24]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0f2  T99W510 4G Modem [Snapdragon X24]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0f5  DW5932e-eSIM 5G Modem [Snapdragon X62]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0f9  DW5932e 5G Modem [Snapdragon X62]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e118  T99W640 5G Modem [Snapdragon X72]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e11d  DW5934e-eSIM 5G Modem [Snapdragon X72]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e11e  DW5934e 5G Modem [Snapdragon X72]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e123  T99W760 5G Redcap Modem [Snapdragon X35]
 105c  Wipro Infotech Limited
 105d  Number 9 Computer Company
 	2309  Imagine 128
@@ -7798,6 +7911,7 @@
 	1020  ISP1020/1040 Fast-wide SCSI
 	1022  ISP1022 Fast-wide SCSI
 	1080  ISP1080 SCSI Host Adapter
+		1077 0001  QLA1080
 	1216  ISP12160 Dual Channel Ultra3 SCSI Processor
 		101e 8471  QLA12160 on AMI MegaRAID
 		101e 8493  QLA12160 on AMI MegaRAID
@@ -7839,6 +7953,11 @@
 		1077 e4f7  FastLinQ QL45212H 25GbE Adapter (SR-IOV VF)
 		1077 e4f8  FastLinQ QL45611H 100GbE Adapter (SR-IOV VF)
 		1590 0245  10/20/25GbE 2P 4820c CNA SRIOV
+	16a1  BCM57840 NetXtreme II 10 Gigabit Ethernet
+		1590 00ec  FlexFabric 10Gb 4-port 536FLR-T Adapter
+	16ab  NetXtreme II BCM57840 10/20 Gigabit Ethernet Multi Function
+	16ad  NetXtreme II BCM57840 10/20 Gigabit Ethernet Virtual Function
+		1590 00ec  FlexFabric 10Gb 4-port 536FLR-T Adapter
 	2020  ISP2020A Fast!SCSI Basic Adapter
 	2031  ISP8324-based 16Gb Fibre Channel to PCI Express Adapter
 		103c 17e7  SN1000Q 16Gb Single Port Fibre Channel Adapter
@@ -9516,7 +9635,7 @@
 		e1c5 0005  TA1-PCI
 		e1c5 0006  TA1-PCI4
 	9036  9036
-	9050  PCI <-> IOBus Bridge
+	9050  PCI9050 32-bit 33MHz PCI <-> IOBus Bridge
 		103c 10b0  82350 PCI GPIB
 		10b5 1067  IXXAT CAN i165
 		10b5 114e  Wasco WITIO PCI168extended
@@ -9552,6 +9671,8 @@
 		15ed 1001  Macrolink MCCS 16-port Serial
 		15ed 1002  Macrolink MCCS 8-port Serial Hot Swap
 		15ed 1003  Macrolink MCCS 16-port Serial Hot Swap
+		1761 018e  40-199-002
+		1761 025d  40-662-001
 		5654 2036  OpenSwitch 6 Telephony card
 		5654 3132  OpenSwitch 12 Telephony card
 		5654 5634  OpenLine4 Telephony Card
@@ -9637,6 +9758,8 @@
 		1885 0701  Tsunami FPGA PMC with Altera Stratix S30
 	9712  PEX9712 12-Lane, 5-Port PCIe Gen 3 (8.0 GT/s) ExpressFabric Switch
 	9733  PEX 9733 33-lane, 9-port PCI Express Gen 3 (8.0 GT/s) Switch
+		1028 1fc7  UCEA-200 0235NK NVMe PCIe Extender Adapter with Full-Height Bracket
+		1028 1fc8  UCEA-200 0CDC7W NVMe PCIe Extender Adapter with Half-Height Bracket
 		1d49 0001  ThinkSystem 1610-4P NVMe Switch Adapter
 		1d49 0002  ThinkSystem 810-4P NVMe Switch Adapter
 	9749  PEX 9749 49-lane, 13-port PCI Express Gen 3 (8.0 GT/s) Switch
@@ -10155,9 +10278,7 @@
 		1102 102f  3D Blaster RIVA TNT2 Ultra
 		14af 5820  Maxi Gamer Xentor 32
 		4843 4f34  Dynamite
-	002a  NV5 [Riva TNT2]
-	002b  NV5 [Riva TNT2]
-	002c  NV5 [Vanta / Vanta LT]
+	002c  NV6 [Vanta LT / Vanta / Vanta-16]
 		1043 0200  AGP-V3800 Combat SDRAM
 		1043 0201  AGP-V3800 Combat
 		1048 0c20  TNT2 Vanta
@@ -10167,7 +10288,7 @@
 		1102 1031  CT6938 VANTA 8MB
 		1102 1034  CT6894 VANTA 16MB
 		14af 5008  Maxi Gamer Phoenix 2
-	002d  NV5 [Riva TNT2 Model 64 / Model 64 Pro]
+	002d  NV6 [Riva TNT2 Model 64 / Model 64 Pro]
 		1043 0200  AGP-V3800M
 		1043 0201  AGP-V3800M
 		1048 0c3a  Erazor III LT
@@ -10326,7 +10447,7 @@
 	0068  nForce2 USB Controller
 		1043 0c11  A7N8X Mainboard
 		a0a0 03b4  UK79G-1394 motherboard
-	006a  nForce2 AC97 Audio Controler (MCP)
+	006a  nForce2 AC97 Audio Controller (MCP)
 		1043 8095  nForce2 AC97 Audio Controller (MCP)
 		a0a0 0304  UK79G-1394 motherboard
 	006b  nForce Audio Processing Unit
@@ -10929,6 +11050,7 @@
 		1043 02fb  V9250 Magic
 		1043 8180  V9520-X/TD/128M
 		107d 2967  WinFast A340T 128MB
+		1462 9073  MS-8907 (FX5200-TDR128)
 		1462 9110  MS-8911 (FX5200-TD128)
 		1462 9171  MS-8917 (FX5200-T128)
 		1462 9360  MS-8936 (FX5200-T128)
@@ -12891,11 +13013,13 @@
 	15fb  GP100GL [GP100 SKU 200]
 	15fc  GP100GL [Tesla P100-DGXS-16GB]
 	15ff  GP100GL [GP100 SKU 15ff]
+	1613  GM204GL [GRID M60 Service Provider]
 	1617  GM204M [GeForce GTX 980M]
 	1618  GM204M [GeForce GTX 970M]
 	1619  GM204M [GeForce GTX 965M]
 	161a  GM204M [GeForce GTX 980 Mobile]
 	1667  GM204M [GeForce GTX 965M]
+	1676  GM204GLM [Quadro M2200 Mobile]
 	1725  GP100
 	172e  GP100
 	172f  GP100
@@ -13147,6 +13271,7 @@
 	1f76  TU106GLM [Quadro RTX 3000 Mobile Refresh]
 	1f81  TU117
 	1f82  TU117 [GeForce GTX 1650]
+		19da 3595  GeForce GTX 1650 OC GDDR6
 	1f83  TU117 [GeForce GTX 1630]
 	1f91  TU117M [GeForce GTX 1650 Mobile / Max-Q]
 	1f92  TU117M [GeForce GTX 1650 Mobile]
@@ -13211,6 +13336,7 @@
 	2182  TU116 [GeForce GTX 1660 Ti]
 	2183  TU116
 	2184  TU116 [GeForce GTX 1660]
+	2186  TU116 [PG160 SKU18]
 	2187  TU116 [GeForce GTX 1650 SUPER]
 	2188  TU116 [GeForce GTX 1650]
 	2189  TU116 [CMP 30HX]
@@ -13225,7 +13351,9 @@
 	2200  GA102
 	2203  GA102 [GeForce RTX 3090 Ti]
 	2204  GA102 [GeForce RTX 3090]
-		147d 10de  NVIDIA Geforce RTX 3090 Founders Edition
+		10de 147d  GeForce RTX 3090 Founders Edition
+		1462 3881  MSI RTX 3090 VENTUS 3X OC
+		3842 3973  GeForce RTX 3090 XC3
 	2205  GA102 [GeForce RTX 3080 Ti 20GB]
 	2206  GA102 [GeForce RTX 3080]
 		10de 1467  GA102 [GeForce RTX 3080]
@@ -13256,12 +13384,21 @@
 	229e  Orin PCIe x1 Root Complex
 	22a3  GH100 [H100 NVSwitch]
 	22ba  AD102 High Definition Audio Controller
+	22bb  AD103 High Definition Audio Controller
 	22bc  AD104 High Definition Audio Controller
 	22bd  AD106M High Definition Audio Controller
 	22be  AD107 High Definition Audio Controller
+	22ce  GB10 GEN5 X4 PCIe host
+	22d0  GB10 GEN4 X1 PCIe host
+	22d1  GB20B PCI bridge
 	22d8  THOR Processor PCI Express Root Port
 	22e6  THOR Processor PCI Express x16 Controller
+	22e8  GB202 High Definition Audio Controller
+	22e9  GB203 High Definition Audio Controller
+	22eb  GB206 High Definition Audio Controller
+	22ec  GB207 High Definition Audio Controller
 	2302  GH100
+	230c  GH100 [H20 NVL16]
 	230e  GH100 [H20 NVL16]
 	2313  GH100 [H100 CNX]
 	2321  GH100 [H100L 94GB]
@@ -13284,6 +13421,7 @@
 	2343  GH100
 	2345  GH100 [GH100-88K-A1]
 	2348  GH100 [GH200 144G HBM3e]
+	237e  GH100 [H100 GH3]
 	237f  GH100 [Skinny Joe]
 	23b0  GH100
 	23f0  GH100
@@ -13331,7 +13469,7 @@
 	24dd  GA104M [GeForce RTX 3070 Mobile / Max-Q]
 	24df  GA104M
 	24e0  GA104M [Geforce RTX 3070 Ti Laptop GPU]
-	24fa  GA104 [RTX A4500 Embedded GPU ]
+	24fa  GA104 [RTX A4500 Embedded GPU]
 	2501  GA106 [GeForce RTX 3060]
 	2503  GA106 [GeForce RTX 3060]
 	2504  GA106 [GeForce RTX 3060 Lite Hash Rate]
@@ -13381,7 +13519,7 @@
 	25e5  GA107BM [GeForce RTX 3050 Mobile]
 	25ec  GA107BM / GN20-P0-R-K2 [GeForce RTX 3050 6GB Laptop GPU]
 	25ed  GA107 [GeForce RTX 2050]
-	25f9  GA107 [RTX A1000 Embedded GPU ]
+	25f9  GA107 [RTX A1000 Embedded GPU]
 	25fa  GA107 [RTX A2000 Embedded GPU]
 	25fb  GA107 [RTX A500 Embedded GPU]
 	2681  AD102 [RTX TITAN Ada]
@@ -13448,6 +13586,7 @@
 	28f8  AD107GLM [RTX 2000 Ada Generation Embedded GPU]
 	2900  GB100 [Reserved Dev ID A]
 	2901  GB100 [B200]
+	2909  GB100 [HGX B200 168GB]
 	2920  GB100 [TS4 / B100]
 	2924  GB100
 	2925  GB100
@@ -13456,46 +13595,83 @@
 	2941  GB100 [HGX GB200]
 	297e  GB100
 	2980  GB102 [Reserved Dev ID A]
+	29bb  GB102 [DRIVE P2021]
 	29bc  GB102 [B100]
 	29c0  GB102 [Reserved Dev ID B]
 	29f1  GB102
-	2b00  TA1090SA [THOR]
+# space added
+	2b00  GB10B [Jetson AGX Thor]
 	2b85  GB202 [GeForce RTX 5090]
 	2b87  GB202 [GeForce RTX 5090 D]
+	2b8c  GB202 [GeForce RTX 5090 D V2]
 	2bb1  GB202GL [RTX PRO 6000 Blackwell Workstation Edition]
-	2bb3  GB202GL [RTX PRO 5000 Blackwell]
+	2bb2  GB202GL [RTX PRO 6000D Blackwell Workstation Edition]
+	2bb3  GB202GL [RTX PRO 5000 Blackwell / RTX PRO 5000 72GB Blackwell]
 	2bb4  GB202GL [RTX PRO 6000 Blackwell Max-Q Workstation Edition]
 	2bb5  GB202GL [RTX PRO 6000 Blackwell Server Edition]
+	2bb9  GB202GL [RTX 6000D]
+	2bbc  GB202GL [RTX PRO 6000D Blackwell Max-Q Workstation Edition]
 	2c02  GB203 [GeForce RTX 5080]
 	2c05  GB203 [GeForce RTX 5070 Ti]
 	2c18  GB203M / GN22 [GeForce RTX 5090 Max-Q / Mobile]
 	2c19  GB203M / GN22 [GeForce RTX 5080 Max-Q / Mobile]
 	2c2c  GB6-256(N22W-ES-A1)
 	2c31  GB203GL [RTX PRO 4500 Blackwell]
+	2c33  GB203GL [RTX PRO 4000 Blackwell SFF Edition]
 	2c34  GB203GL [RTX PRO 4000 Blackwell]
 	2c38  GB203GLM [RTX PRO 5000 Blackwell Generation Laptop GPU]
 	2c39  GB203GLM [RTX PRO 4000 Blackwell Generation Laptop GPU]
+	2c3a  GB203GL [RTX PRO 4500 Blackwell Server Edition]
 	2c58  GB203M / GN22-X11 [GeForce RTX 5090 Max-Q / Mobile]
 	2c59  GB203M / GN22-X9 [GeForce RTX 5080 Max-Q / Mobile]
+	2c77  GB203GLM [RTX PRO 5000 Blackwell Embedded GPU]
+	2c79  GB203GLM [RTX PRO 4000 Blackwell Embedded GPU]
 	2d04  GB206 [GeForce RTX 5060 Ti]
 	2d05  GB206 [GeForce RTX 5060]
 	2d18  GB206M [GeForce RTX 5070 Max-Q / Mobile]
 	2d19  GB206M [GeForce RTX 5060 Max-Q / Mobile]
 	2d2c  GB6-128 (N22Y-ES-A1)
+	2d30  GB206GL [RTX PRO 2000 Blackwell]
 	2d39  GB206GLM [RTX PRO 2000 Blackwell Generation Laptop GPU]
 	2d58  GB206M [GeForce RTX 5070 Max-Q / Mobile]
 	2d59  GB206M [GeForce RTX 5060 Max-Q / Mobile]
+	2d79  GB206GLM [RTX PRO 2000 Blackwell Embedded GPU]
 	2d83  GB207 [GeForce RTX 5050]
 	2d98  GB207M [GeForce RTX 5050 Max-Q / Mobile]
 	2db8  GB207GLM [RTX PRO 1000 Blackwell Generation Laptop GPU]
 	2db9  GB207GLM [RTX PRO 500 Blackwell Generation Laptop GPU]
 	2dd8  GB207M [GeForce RTX 5050 Max-Q / Mobile]
-	2e2a  GB20B
+	2df9  GB207GLM [RTX PRO 500 Blackwell Embedded GPU]
+	2e03  GB20B [RTX Spark N1X (6144-core Blackwell RTX GPU)]
+	2e06  GB20B [RTX Spark N1X (5120-core Blackwell RTX GPU)]
+	2e12  GB20B [GB10]
+	2e13  GB20B [Desktop Device]
+# N1X
+	2e2a  GB20B [JMJWOA-Generic-GPU]
 	2f04  GB205 [GeForce RTX 5070]
+	2f06  GB205 [GeForce RTX 5060]
 	2f18  GB205M [GeForce RTX 5070 Ti Mobile]
 	2f38  GB205GLM [RTX PRO 3000 Blackwell Generation Laptop GPU]
 	2f58  GB205M [GeForce RTX 5070 Ti Mobile]
-	31c0  GB110
+	2f80  GB205 High Definition Audio Controller
+	2f95  Vera Rubin CPU
+	2f96  Vera Rubin CPU
+	2f97  Vera Rubin CPU
+	2f98  Vera Rubin CPU
+	3000  GR100 [Reserved Dev ID A]
+	3021  GR100 [PCIe Faber]
+	3040  GR100 [Reserved Dev ID B]
+	30c0  GR102
+	3180  GB110 [Reserved Dev ID A]
+	3182  GB110 [B300 SXM6 AC]
+	31a1  GB110 [GB300 MaxQ]
+	31c0  GB110 [Reserved Dev ID B]
+	31c2  GB110 [GB300]
+	31c3  GB110 [GB300]
+	31fe  GB110
+	3200  GB112
+	3224  GB112
+	323e  GB112
 	3340  GB120
 10df  Emulex Corporation
 	0720  OneConnect NIC (Skyhawk)
@@ -13517,6 +13693,7 @@
 	072b  OneConnect iSCSI Initiator + Target (Skyhawk-VF)
 	072c  OneConnect FCoE Initiator (Skyhawk-VF)
 	1ae5  LP6000 Fibre Channel Host Adapter
+	d300  LPE41100/LPE42100 Series 64G/128G Fibre Channel Adapter
 	e100  Proteus-X: LightPulse IOV Fibre Channel Host Adapter
 	e131  LightPulse 8Gb/s PCIe Shared I/O Fibre Channel Adapter
 	e180  Proteus-X: LightPulse IOV Fibre Channel Host Adapter
@@ -13598,6 +13775,9 @@
 	f500  LPe37000/LPe38000 Series 32Gb/64Gb Fibre Channel Adapter
 		1014 06c1  PCIe4 4-Port 32Gb Fibre Channel Adapter for POWER (FC EN1L/EN1M; CCIN 2CFC)
 		1014 06c2  PCIe4 2-Port 64Gb Fibre Channel Adapter for POWER (FC EN1N/EN1P; CCIN 2CFD)
+		1590 042e  Synergy 7330C 64Gb Fibre Channel Host Bus Adapter
+		1590 0451  SN1620E 2-Port 32Gb Fibre Channel Adapter
+		1590 0452  SN1720E 2-Port 64Gb Fibre Channel Adapter
 		1590 0454  Synergy 5331C 32Gb Fibre Channel Host Bus Adapter
 	f600  LPe37100S/LPe38100S Series 32Gb/64Gb Fibre Channel Adapter
 	f700  LP7000 Fibre Channel Host Adapter
@@ -13713,6 +13893,7 @@
 	2600  Killer E2600 GbE Controller
 	3000  Killer E3000 2.5GbE Controller
 	4321  RTL8852BE 802.11ax PCIe Wireless Network Adapter
+	5000  Killer E5000 5GbE Controller
 	5208  RTS5208 PCI Express Card Reader
 	5209  RTS5209 PCI Express Card Reader
 	5227  RTS5227 PCI Express Card Reader
@@ -13767,6 +13948,7 @@
 	8125  RTL8125 2.5GbE Controller
 		4c52 2022  LRES2022PT Single-port 2.5Gb Ethernet Network Adapter
 	8126  RTL8126 5GbE Controller
+	8127  RTL8127 10GbE Controller
 	8129  RTL-8129
 		10ec 8129  RT8129 Fast Ethernet Adapter
 		11ec 8129  RTL8111/8168 PCIe Gigabit Ethernet (misconfigured)
@@ -13913,7 +14095,7 @@
 		ea50 ce19  mCOM10-L1900
 	816d  RTL811x EHCI host controller
 		ea50 ce19  mCOM10-L1900
-	816e  Realtek RealManage BMC
+	816e  RealManage BMC
 	8171  RTL8191SEvA Wireless LAN Controller
 	8172  RTL8191SEvB Wireless LAN Controller
 	8173  RTL8192SE Wireless LAN Controller
@@ -13929,6 +14111,7 @@
 		1385 4700  MA521 802.11b Wireless PC Card
 		1737 0019  WPC11v4 802.11b Wireless-B Notebook Adapter
 	8185  RTL-8185 IEEE 802.11a/b/g Wireless LAN Controller
+		187e 8225  ZyAIR G-302 v3
 	818b  RTL8192EE PCIe Wireless Network Adapter
 	8190  RTL8190 802.11n PCI Wireless Network Adapter
 	8191  RTL8192CE PCIe Wireless Network Adapter
@@ -14177,7 +14360,8 @@
 	000b  EMU20k2 [Sound Blaster X-Fi Titanium Series]
 		1102 0041  SB0880 [SoundBlaster X-Fi Titanium PCI-e]
 		1102 0062  SB1270 [SoundBlaster X-Fi Titanium HD]
-	0010  CA0132 Sound Core3D [Sound Blaster AE-7]
+	0010  CA0132 Sound Core3D [Sound Blaster AE-7/AE-9]
+		1102 0071  Sound Blaster AE-9
 		1102 0081  Sound Blaster AE-7
 	0012  CA0132 Sound Core3D [Sound Blaster Recon3D / Z-Series / Sound BlasterX AE-5 Plus]
 		1102 0010  SB1570 SB Audigy Fx
@@ -14322,6 +14506,7 @@
 	0410  VX900 Series Host Bridge: Host Control
 	0415  VT6415 PATA IDE Host Controller
 		1043 838f  Motherboard
+		1849 0415  Motherboard
 	0419  VN1000 Host Bridge
 	0501  VT8501 [Apollo MVP4]
 	0505  VT82C505
@@ -16131,6 +16316,8 @@
 		117c 00c9  Celerity FC-641E
 		117c 00ca  Celerity FC-642E
 		117c 00d4  Celerity FC-644E
+		117c 40d8  ThunderLink FC 5642
+		117c 40d9  ThunderLink FC 5322
 	00c5  ExpressNVM PCIe Gen4 Switch
 		117c 00c6  ExpressNVM S48F PCIe Gen4
 		117c 00cb  ExpressNVM S4FF PCIe Gen4
@@ -16140,6 +16327,11 @@
 		117c 00c2  ExpressSAS H1244 GT
 		117c 00c3  ExpressSAS H12F0 GT
 		117c 00c4  ExpressSAS H120F GT
+		117c 00e1  ExpressSAS H1280 GT
+		117c 00e2  ExpressSAS H1208 GT
+		117c 00e3  ExpressSAS H1244 GT
+		117c 40e0  ThunderLink SH 5128
+		117c 40e4  ThunderLink SH 5128
 	8013  ExpressPCI UL4D
 	8014  ExpressPCI UL4S
 	8027  ExpressPCI UL5D
@@ -16147,7 +16339,7 @@
 		117c 0070  ExpressSAS H1280
 		117c 0071  ExpressSAS H1208
 		117c 0080  ExpressSAS H1244
-		117c 40ae  ThunderLink TLSH-3128
+		117c 40ae  ThunderLink SH 3128
 	8072  ExpressSAS 12Gb/s SAS/SATA HBA
 		117c 0072  ExpressSAS H12F0
 		117c 0073  ExpressSAS H120F
@@ -16282,7 +16474,7 @@
 		1324 10cf  P7120
 		17aa 20cb  ThinkPad T400
 	e230  R5U2xx (R5U230 / R5U231 / R5U241) [Memory Stick Host Controller]
-	e476  CardBus bridge
+	e476  R5U242 PCIe to CardBus Bridge
 		1028 040a  Latitude E6410
 		1028 040b  Latitude E6510
 	e822  MMC/SD Host Controller
@@ -16439,11 +16631,15 @@
 	138f  W8300 802.11 Adapter (rev 07)
 	1fa6  Marvell W8300 802.11 Adapter
 		1186 3b08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.A1)
+		1186 3b09  AirPlus G DWL-G510 Wireless G PCI Card
 	1fa7  88W8310 and 88W8000G [Libertas] 802.11g client chipset
 	1faa  88w8335 [Libertas] 802.11b/g Wireless
+		1186 3b21  EH101 Wireless G Notebook Adapter
+		1186 3b22  EH102 Wireless G Desktop Adapter
 		1385 4e00  WG511v2 54 Mbps Wireless PC Card
 		1385 6b00  WG311v3 802.11g Wireless PCI Adapter
 		1737 0040  WPC54G v5 802.11g Wireless-G Notebook Adapter
+		a727 6802  3CRGPC10075 OfficeConnect Wireless 54Mbps 11g PC Card
 	2211  88SB2211 PCI Express to PCI Bridge
 	2a01  88W8335 [Libertas] 802.11b/g Wireless
 	2a02  88W8361 [TopDog] 802.11n Wireless
@@ -16451,9 +16647,14 @@
 		1385 7c00  WN511T RangeMax Next 300 Mbps Wireless PC Card
 		1385 7c01  WN511T RangeMax Next 300 Mbps Wireless Notebook Adapter
 		1385 7e00  WN311T RangeMax Next 300 Mbps Wireless PCI Adapter
+		1737 0065  WPC4400N Wireless-N Business Notebook Adapter
 		1799 801b  F5D8011 v2 802.11n N1 Wireless Notebook Card
 	2a08  88W8362e [TopDog] 802.11a/b/g/n Wireless
 	2a0a  88W8363 [TopDog] 802.11n Wireless
+	2a0b  88W8363 [TopDog] 802.11n Wireless
+		1154 0356  WLI-CB-AMG144N
+		1154 0357  WLI-CB-AG300N Nfiniti 802.11a/g/b + Draft 802.11n CardBus Card
+		1154 035c  WLI-CB-AMG300N
 	2a0c  88W8363 [TopDog] 802.11n Wireless
 	2a24  88W8363 [TopDog] 802.11n Wireless
 	2a2b  88W8687 [TopDog] 802.11b/g Wireless
@@ -16642,6 +16843,7 @@
 	6180  88F6180 [Kirkwood] ARM SoC
 	6192  88F6190/6192 [Kirkwood] ARM SoC
 	6281  88F6281 [Kirkwood] ARM SoC
+	6282  88F6282 [Armada 300] ARM SoC
 # This device ID was used for earlier chips.
 	6381  MV78xx0 [Discovery Innovation] ARM SoC
 	6440  88SE63x0 x1, 88SE6440 x4 PCIe SAS/SATA 3Gb/s RAID controller
@@ -16876,7 +17078,8 @@
 11c9  Magma
 	0010  16-line serial port w/- DMA
 	0011  4-line serial port w/- DMA
-11ca  LSI Systems, Inc
+11ca  IBEX Technology Co., Ltd.
+	0039  PAC with Altera Agilex 7 FPGA M-Series [IPAC-1000]
 11cb  Specialix Research Ltd.
 	2000  PCI_9050
 		11cb 0200  SX
@@ -17006,10 +17209,33 @@
 11f7  Scientific Atlanta
 # née PMC-Sierra Inc.
 11f8  Microchip Technology
+	4000  PM40100 Switchtec PFX 100xG4 Fanout PCIe Switch
+	4028  PM40028 Switchtec PFX 28xG4 Fanout PCIe Switch
 	4036  PM40036 Switchtec PFX 36xG4 Fanout PCIe Switch
 	4052  PM40052 Switchtec PFX 52xG4 Fanout PCIe Switch
+	4068  PM40068 Switchtec PFX 68xG4 Fanout PCIe Switch
 	4084  PM40084 Switchtec PFX 84xG4 Fanout PCIe Switch
+	4100  PM41100 Switchtec PSX 100xG4 Programmable PCIe Switch
 	4128  PM41028 Switchtec PSX 28xG4 Programmable PCIe Switch
+	4136  PM41036 Switchtec PSX 36xG4 Programmable PCIe Switch
+	4152  PM41052 Switchtec PSX 52xG4 Programmable PCIe Switch
+	4168  PM41068 Switchtec PSX 68xG4 Programmable PCIe Switch
+	4184  PM41084 Switchtec PSX 84xG4 Programmable PCIe Switch
+	4200  PM42100 Switchtec PAX 100xG4 Programmable Advanced Fabric PCIe Switch
+	4228  PM42028 Switchtec PAX 28xG4 Programmable Advanced Fabric PCIe Switch
+	4236  PM42036 Switchtec PAX 36xG4 Programmable Advanced Fabric PCIe Switch
+	4252  PM42052 Switchtec PAX 52xG4 Programmable Advanced Fabric PCIe Switch
+	4268  PM42068 Switchtec PAX 68xG4 Programmable Advanced Fabric PCIe Switch
+	4284  PM42084 Switchtec PAX 84xG4 Programmable Advanced Fabric PCIe Switch
+	4328  PM43028 Switchtec PFXA 28xG4 Automotive Fanout PCIe Switch
+	4336  PM43036 Switchtec PFXA 36xG4 Automotive Fanout PCIe Switch
+	4352  PM43052 Switchtec PFXA 52xG4 Automotive Fanout PCIe Switch
+	4428  PM44028 Switchtec PSXA 28xG4 Automotive Programmable PCIe Switch
+	4436  PM44036 Switchtec PSXA 36xG4 Automotive Programmable PCIe Switch
+	4452  PM44052 Switchtec PSXA 52xG4 Automotive Programmable PCIe Switch
+	4528  PM45028 Switchtec PAXA 28xG4 Automotive Programmable Advanced Fabric PCIe Switch
+	4536  PM45036 Switchtec PAXA 36xG4 Automotive Programmable Advanced Fabric PCIe Switch
+	4552  PM45052 Switchtec PAXA 52xG4 Automotive Programmable Advanced Fabric PCIe Switch
 	5000  PM50100 Switchtec PFX 100xG5 Fanout PCIe Switch
 	5028  PM50028 Switchtec PFX 28xG5 Fanout PCIe Switch
 	5036  PM50036 Switchtec PFX 36xG5 Fanout PCIe Switch
@@ -17022,10 +17248,66 @@
 	5152  PM51052 Switchtec PSX 52xG5 Programmable PCIe Switch
 	5168  PM51068 Switchtec PSX 68xG5 Programmable PCIe Switch
 	5184  PM51084 Switchtec PSX 84xG5 Programmable PCIe Switch
+	5200  PM52100 Switchtec PAX 100xG5 Programmable Advanced Fabric PCIe Switch
 	5220  BR522x [PMC-Sierra maxRAID SAS Controller]
+	5228  PM52028 Switchtec PAX 28xG5 Programmable Advanced Fabric PCIe Switch
+	5236  PM52036 Switchtec PAX 36xG5 Programmable Advanced Fabric PCIe Switch
+	5252  PM52052 Switchtec PAX 52xG5 Programmable Advanced Fabric PCIe Switch
+	5268  PM52068 Switchtec PAX 68xG5 Programmable Advanced Fabric PCIe Switch
+	5284  PM52084 Switchtec PAX 84xG5 Programmable Advanced Fabric PCIe Switch
+	5300  PM53100 Switchtec PFXA 100xG5 Automotive Fanout PCIe Switch
+	5328  PM53028 Switchtec PFXA 28xG5 Automotive Fanout PCIe Switch
+	5336  PM53036 Switchtec PFXA 36xG5 Automotive Fanout PCIe Switch
+	5352  PM53052 Switchtec PFXA 52xG5 Automotive Fanout PCIe Switch
+	5368  PM53068 Switchtec PFXA 68xG5 Automotive Fanout PCIe Switch
+	5384  PM53084 Switchtec PFXA 84xG5 Automotive Fanout PCIe Switch
+	5400  PM54100 Switchtec PSXA 100xG5 Automotive Programmable PCIe Switch
+	5428  PM54028 Switchtec PSXA 28xG5 Automotive Programmable PCIe Switch
+	5436  PM54036 Switchtec PSXA 36xG5 Automotive Programmable PCIe Switch
+	5452  PM54052 Switchtec PSXA 52xG5 Automotive Programmable PCIe Switch
+	5468  PM54068 Switchtec PSXA 68xG5 Automotive Programmable PCIe Switch
+	5484  PM54084 Switchtec PSXA 84xG5 Automotive Programmable PCIe Switch
+	5500  PM55100 Switchtec PAXA 100xG5 Automotive Programmable Advanced Fabric PCIe Switch
+	5528  PM55028 Switchtec PAXA 28xG5 Automotive Programmable Advanced Fabric PCIe Switch
+	5536  PM55036 Switchtec PAXA 36xG5 Automotive Programmable Advanced Fabric PCIe Switch
+	5552  PM55052 Switchtec PAXA 52xG5 Automotive Programmable Advanced Fabric PCIe Switch
+	5568  PM55068 Switchtec PAXA 68xG5 Automotive Programmable Advanced Fabric PCIe Switch
+	5584  PM55084 Switchtec PAXA 84xG5 Automotive Programmable Advanced Fabric PCIe Switch
+	6044  PM60144 Switchtec PFXs 144xG6 Secure-capable Fanout PCIe Switch
+	6048  PM60048 Switchtec PFXs 48xG6 Secure-capable Fanout PCIe Switch
+	6060  PM60160 Switchtec PFXs 160xG6 Secure-capable Fanout PCIe Switch
+	6064  PM60064 Switchtec PFXs 64xG6 Secure-capable Fanout PCIe Switch
+	6144  PM61144 Switchtec PSXs 144xG6 Secure-capable Programmable PCIe Switch
+	6148  PM61048 Switchtec PSXs 48xG6 Secure-capable Programmable PCIe Switch
+	6160  PM61160 Switchtec PSXs 160xG6 Secure-capable Programmable PCIe Switch
+	6164  PM61064 Switchtec PSXs 64xG6 Secure-capable Programmable PCIe Switch
+	6244  PM62144 Switchtec PFX 144xG6 Fanout PCIe Switch
+	6248  PM62048 Switchtec PFX 48xG6 Fanout PCIe Switch
+	6260  PM62160 Switchtec PFX 160xG6 Fanout PCIe Switch
+	6264  PM62064 Switchtec PFX 64xG6 Fanout PCIe Switch
+	6344  PM63144 Switchtec PSX 144xG6 Programmable PCIe Switch
+	6348  PM63048 Switchtec PSX 48xG6 Programmable PCIe Switch
+	6360  PM63160 Switchtec PSX 160xG6 Programmable PCIe Switch
+	6364  PM63064 Switchtec PSX 64xG6 Programmable PCIe Switch
+	7044  PM70144 Switchtec PFXs 144xG7 Secure-capable Fanout PCIe Switch
+	7048  PM70048 Switchtec PFXs 48xG7 Secure-capable Fanout PCIe Switch
+	7060  PM70160 Switchtec PFXs 160xG7 Secure-capable Fanout PCIe Switch
+	7064  PM70064 Switchtec PFXs 64xG7 Secure-capable Fanout PCIe Switch
+	7144  PM71144 Switchtec PSXs 144xG7 Secure-capable Programmable PCIe Switch
+	7148  PM71048 Switchtec PSXs 48xG7 Secure-capable Programmable PCIe Switch
+	7160  PM71160 Switchtec PSXs 160xG7 Secure-capable Programmable PCIe Switch
+	7164  PM71064 Switchtec PSXs 64xG7 Secure-capable Programmable PCIe Switch
+	7244  PM72144 Switchtec PFX 144xG7 Fanout PCIe Switch
+	7248  PM72048 Switchtec PFX 48xG7 Fanout PCIe Switch
+	7260  PM72160 Switchtec PFX 160xG7 Fanout PCIe Switch
+	7264  PM72064 Switchtec PFX 64xG7 Fanout PCIe Switch
 	7364  PM7364 [FREEDM - 32 Frame Engine & Datalink Mgr]
 	7375  PM7375 [LASAR-155 ATM SAR]
 	7384  PM7384 [FREEDM - 84P672 Frm Engine & Datalink Mgr]
+	7444  PM74144 Switchtec PSX 144xG7 Programmable PCIe Switch
+	7448  PM74048 Switchtec PSX 48xG7 Programmable PCIe Switch
+	7460  PM74160 Switchtec PSX 160xG7 Programmable PCIe Switch
+	7464  PM74064 Switchtec PSX 64xG7 Programmable PCIe Switch
 	8000  PM8000  [SPC - SAS Protocol Controller]
 	8009  PM8009 SPCve 8x6G
 	8018  PM8018 Adaptec SAS Adaptor ASA-70165H PCIe Gen3 x8 6 Gbps 16-lane 4x SFF-8644
@@ -17051,8 +17333,30 @@
 	8535  PM8535 PFX 80xG3 PCIe Fanout Switch
 	8536  PM8536 PFX 96xG3 PCIe Fanout Switch
 		1bd4 0081  PM8536 PFX 96xG3 PCIe Fanout Switch
+	8541  PM8541 PSX 24xG3 Programmable PCIe Switch
+	8542  PM8542 PSX 32xG3 Programmable PCIe Switch
+	8543  PM8543 PSX 48xG3 Programmable PCIe Switch
+	8544  PM8544 PSX 64xG3 Programmable PCIe Switch
+	8545  PM8545 PSX 80xG3 Programmable PCIe Switch
 	8546  PM8546 B-FEIP PSX 96xG3 PCIe Storage Switch
+	8551  PM8551 PAX 24xG3 Programmable Advanced Fabric PCIe Switch
+	8552  PM8552 PAX 32xG3 Programmable Advanced Fabric PCIe Switch
+	8553  PM8553 PAX 48xG3 Programmable Advanced Fabric PCIe Switch
+	8554  PM8554 PAX 64xG3 Programmable Advanced Fabric PCIe Switch
+	8555  PM8555 PAX 80xG3 Programmable Advanced Fabric PCIe Switch
+	8556  PM8556 PAX 96xG3 Programmable Advanced Fabric PCIe Switch
+	8561  PM8561 Switchtec PFX-L 24xG3 Fanout-Lite PCIe Switch
 	8562  PM8562 Switchtec PFX-L 32xG3 Fanout-Lite PCIe Gen3 Switch
+	8563  PM8563 Switchtec PFX-L 48xG3 Fanout-Lite PCIe Switch
+	8564  PM8564 Switchtec PFX-L 64xG3 Fanout-Lite PCIe Switch
+	8565  PM8565 Switchtec PFX-L 80xG3 Fanout-Lite PCIe Switch
+	8566  PM8566 Switchtec PFX-L 96xG3 Fanout-Lite PCIe Switch
+	8571  PM8571 Switchtec PFX-I 24xG3 Industrial Fanout PCIe Switch
+	8572  PM8572 Switchtec PFX-I 32xG3 Industrial Fanout PCIe Switch
+	8573  PM8573 Switchtec PFX-I 48xG3 Industrial Fanout PCIe Switch
+	8574  PM8574 Switchtec PFX-I 64xG3 Industrial Fanout PCIe Switch
+	8575  PM8575 Switchtec PFX-I 80xG3 Industrial Fanout PCIe Switch
+	8576  PM8576 Switchtec PFX-I 96xG3 Industrial Fanout PCIe Switch
 11f9  I-Cube Inc
 11fa  Kasan Electronics Company, Ltd.
 11fb  Datel Inc
@@ -17215,7 +17519,7 @@
 		103c 0890  NC6000 laptop
 		10cf 11c4  Lifebook P5020D Laptop
 	7233  OZ711MP3/MS3 4-in-1 MemoryCardBus Controller
-	8120  Integrated MMC/SD Controller
+	8120  OZ888 SD/MMC Card Reader Controller
 	8130  Integrated MS/MSPRO/xD Controller
 	8220  OZ600FJ1/OZ900FJ1 SD/MMC Card Reader Controller
 	8221  OZ600FJ0/OZ900FJ0/OZ600FJS SD/MMC Card Reader Controller
@@ -17225,9 +17529,11 @@
 	8330  OZ600 MS/xD Controller
 		1028 04a3  Precision M4600
 	8331  O2 Flash Memory Card
-	8520  SD/MMC Card Reader Controller
-	8621  SD/MMC Card Reader Controller
+	8520  OZ777 SD/MMC Card Reader Controller
+	8620  OZ620 SD/MMC Card Reader Controller
+	8621  OZ711 SD/MMC Card Reader Controller
 		17aa 5068  Thinkpad E480/E580
+		1e44 1776  Steam Deck
 	8760  FORESEE E2M2 NVMe SSD
 1218  Hybricon Corp.
 1219  First Virtual Corporation
@@ -17337,6 +17643,7 @@
 1233  Bus-Tech, Inc.
 # nee Risq Modular Systems, Inc.
 1235  SMART Modular Technologies
+	5820  DC5820 NVMe SSD
 	c241  CXA-4F1W
 		1028 2382  4-DIMM Add In Card
 1236  Sigma Designs Corporation
@@ -17452,7 +17759,8 @@
 		a000 2000  Parallel Port
 		a000 6000  SPI
 		a000 7000  Local Bus
-		ea50 1c10  RXi2-BP
+		ea50 1c10  RXi2-BP Serial Port
+	9105  AX99100 PCIe to I/O Bridge
 125c  Aurora Technologies, Inc.
 	0101  Saturn 4520P
 	0640  Aries 16000P
@@ -17518,12 +17826,16 @@
 	3872  ISL3872 [Prism 3]
 		1468 0202  LAN-Express IEEE 802.11b Wireless LAN
 	3873  ISL3874 [Prism 2.5]/ISL3872 [Prism 3]
+		10b7 0001  3CRDW696 rev A Wireless LAN PCI Adapter [ISL3874]
 		10cf 1169  MBH7WM01-8734 802.11b Wireless Mini PCI Card [ISL3874]
+		10fc d009  WN-B11/PCIH
 		1186 3501  DWL-520 Wireless PCI Adapter (rev A or B) [ISL3874]
 		1186 3700  DWL-520 Wireless PCI Adapter (rev E1) [ISL3872]
 		1385 4105  MA311 802.11b wireless adapter [ISL3874]
 		1668 0414  HWP01170-01 802.11b PCI Wireless Adapter
+		1668 1406  802MIP 802.11b Mini PCI Adapter [ISL3874]
 		16a5 1601  AIR.mate PC-400 PCI Wireless LAN Adapter
+		16be 2001  CTX712
 		1737 3874  WMP11 v1 802.11b Wireless-B PCI Adapter [ISL3874]
 		4033 7033  PCW200 802.11b Wireless PCI Adapter [ISL3874]
 		8086 2510  M3AWEB Wireless 802.11b MiniPCI Adapter
@@ -17597,6 +17909,8 @@
 	2263  SM2263EN/SM2263XT (DRAM-less) NVMe SSD Controllers
 	2268  SM2268XT (DRAM-less) NVMe SSD Controller
 	2269  SM2269XT (DRAM-less) NVMe SSD Controller
+	2504  SM2504XT NVMe 2.0 SSD Controller (DRAM-less)
+	2508  SM2508 NVMe 2.0 SSD Controller
 	8366  SM8366 NVMe SSD Controller [MonTitan]
 1270  Olympus Optical Co., Ltd.
 1271  GW Instruments
@@ -17952,6 +18266,11 @@
 		12b9 00d3  USR 56K Internal V92 FAX Modem (Model 5610)
 		12b9 baba  USR 56K Internal Voice Modem 3CP3298-DEL (Model 5601) [Hawk]
 12ba  BittWare, Inc.
+	0069  VectorPath S7t-VG6
+		12ba b5d4  BW_BMC_IF
+	0079  VectorPath VP815
+		12ba b5d4  BW_BMC_IF
+	007a  VectorPath VP708
 12bb  Nippon Unisoft Corporation
 12bc  Array Microsystems
 12bd  Computerm Corp.
@@ -18088,6 +18407,7 @@
 	e110  PI7C9X110 PCIe- to-PCI bridge
 		1775 11cc  CC11/CL11 CompactPCI Bridge
 	e111  PI7C9X111SL PCIe-to-PCI Reversible Bridge
+		ea50 3bbb  OCuLink to RX3i backplane bridge
 	e112  PI7C9X112SL PCIe-to-PCI Bridge
 	e113  PI7C9X113SL/PI7C9X118SL PCIe-to-PCI Bridge
 	e130  PCI Express to PCI-XPI7C9X130 PCI-X Bridge
@@ -18194,6 +18514,9 @@
 1303  Innovative Integration
 	0030  X3-SDF 4-channel XMC acquisition board
 1304  Juniper Networks
+	007b  TMC Chassis Interface
+	007c  TMC PFE Interface
+	00c5  Supercon FPGA
 1305  Netphone, Inc
 1306  Duet Technologies
 # Nee ComputerBoards
@@ -18558,11 +18881,59 @@
 		1028 2293  DC NVMe SED 7450 MU U.2 12.8TB
 		1028 2294  DC NVMe ISE 7450 MU U.2 12.8TB
 		1344 3000  U.3 1600GB [MTFDKCB1T6TFS/MTFDKCC1T6TFS]
+	51c9  7600 PRO NVMe SSD
+		1028 2421  MTFDLBQ1T9THG-1BP1DFCDA
+		1028 2422  MTFDLBQ3T8THG-1BP1DFCDA
+		1028 2423  MTFDLBQ7T6THG-1BP1DFCDA
+		1028 2424  MTFDLBQ15T3THG-1BP1DFCDA
+		1028 2429  MTFDLBQ1T9THG-1BP1JABDA
+		1028 242a  MTFDLBQ3T8THG-1BP1JABDA
+		1028 242b  MTFDLBQ7T6THG-1BP1JABDA
+		1028 242c  MTFDLBQ15T3THG-1BP1JABDA
+		1028 2431  MTFDLAL1T9THG-1BP1DFCDA
+		1028 2432  MTFDLAL3T8THG-1BP1DFCDA
+		1028 2433  MTFDLAL7T6THG-1BP1DFCDA
+		1028 2434  MTFDLAL15T3THG-1BP1DFCDA
+		1028 2439  MTFDLAL1T9THG-1BP1JABDA
+		1028 243a  MTFDLAL3T8THG-1BP1JABDA
+		1028 243b  MTFDLAL7T6THG-1BP1JABDA
+		1028 243c  MTFDLAL15T3THG-1BP1JABDA
+	51ca  7600 MAX NVMe SSD
+		1028 2425  MTFDLBQ1T6THS-1BP1DFCDA
+		1028 2426  MTFDLBQ3T2THS-1BP1DFCDA
+		1028 2427  MTFDLBQ6T4THS-1BP1DFCDA
+		1028 2428  MTFDLBQ12T8THS-1BP1DFCDA
+		1028 242d  MTFDLBQ1T6THS-1BP1JABDA
+		1028 242e  MTFDLBQ3T2THS-1BP1JABDA
+		1028 242f  MTFDLBQ6T4THS-1BP1JABDA
+		1028 2430  MTFDLBQ12T8THS-1BP1JABDA
+		1028 2435  MTFDLAL1T6THS-1BP1DFCDA
+		1028 2436  MTFDLAL3T2THS-1BP1DFCDA
+		1028 2437  MTFDLAL6T4THS-1BP1DFCDA
+		1028 2438  MTFDLAL12T8THS-1BP1DFCDA
+		1028 243d  MTFDLAL1T6THS-1BP1JABDA
+		1028 243e  MTFDLAL3T2THS-1BP1JABDA
+		1028 243f  MTFDLAL6T4THS-1BP1JABDA
+		1028 2440  MTFDLAL12T8THS-1BP1JABDA
 	51cb  6550 ION NVMe SSD
 		1028 2379  MTFDLBQ61T4THL-1BK1JABDA
 		1028 23a6  MTFDLBQ30T7THL-1BK1JABDA
 		1028 23a7  MTFDLAL61T4THL-1BK1JABDA
 		1028 23a8  MTFDLAL30T7THL-1BK1JABDA
+	51cc  6600 ION NVMe SSD
+		1028 2453  MTFDLBQ122T8QHF-1BQ1JABDA
+		1028 2483  MTFDLBQ61T4QHF-1BQ1JABDA
+		1028 2484  MTFDLBQ30T7QHF-1BQ1JABDA
+		1028 2485  MTFDLBQ122T8QHF-1BQ1DFCDA
+		1028 2486  MTFDLBQ61T4QHF-1BQ1DFCDA
+		1028 2487  MTFDLBQ30T7QHF-1BQ1DFCDA
+		1028 2489  MTFDLAL122T8QHF-1BQ1JABDA
+		1028 248a  MTFDLAL61T4QHF-1BQ1JABDA
+		1028 248b  MTFDLAL30T7QHF-1BQ1JABDA
+		1028 248d  MTFDLAL122T8QHF-1BQ1DFCDA
+		1028 248e  MTFDLAL61T4QHF-1BQ1DFCDA
+		1028 248f  MTFDLAL30T7QHF-1BQ1DFCDA
+	51cd  9650 PRO NVMe SSD
 	5404  2210 NVMe SSD [Cobain]
 	5405  2300 NVMe SSD [Santana]
 	5407  3400 NVMe SSD [Hendrix]
@@ -18577,6 +18948,8 @@
 	5428  4600 NVMe SSD
 	5429  2600 NVMe SSD (DRAM-less)
 	6001  2100AI NVMe SSD [Nitro]
+	6003  4150AT NVMe SSD
+	6004  4100AT NVMe SSD (DRAM-less)
 1345  Arescom Inc
 1347  Odetics
 1349  Sumitomo Electric Industries, Ltd.
@@ -19038,8 +19411,13 @@
 	0252  XR17V252 Dual UART PCI controller
 	0254  XR17V254 Quad UART PCI controller
 	0258  XR17V258 Octal UART PCI controller
-	0352  XR17V3521 Dual PCIe UART
+	0352  XR17V352 High Performance Dual PCI Express UART
 		4c52 9252  LRUS9252H 2-Port RS232 Serial Adapter
+	0354  XR17V354 High Performance Quad PCI Express UART
+	0358  XR17V358 High Performance Octal PCI Express UART
+		ea50 8232  8-Channel RS232 Card
+	8358  Twin XR17V358 High Performance Octal PCI Express UARTs
+		ea50 8232  16-Channel RS232 Card
 13a9  Siemens Medical Systems, Ultrasound Group
 13aa  Broadband Networks Inc
 13ab  Arcom Control Systems Ltd
@@ -19053,6 +19431,8 @@
 13b3  Lanart Corporation
 13b4  Wellbean Co Inc
 13b5  ARM
+	0300  Integrated [AGI CPU] PCIe/CXL Root Port
+	0301  Integrated [AGI CPU] Platform PCIe Root Port
 13b6  Dlog GmbH
 13b7  Logic Devices Inc
 13b8  Nokia Telecommunications oy
@@ -19446,6 +19826,10 @@
 	5821  Xenos GPU (Zephyr/Falcon)
 	5831  Xenos GPU (Jasper)
 	5841  Xenos GPU (Slim)
+	c030  OpenVMM PCIe Root Port
+	c031  OpenVMM PCIe Switch Upstream Port
+	c032  OpenVMM PCIe Switch Downstream Port
+	c03e  OpenVMM NVMe Controller
 1415  Oxford Semiconductor Ltd
 	8401  OX9162 Mode 1 (8-bit bus)
 	8403  OX9162 Mode 0 (parallel port)
@@ -20327,6 +20711,8 @@
 1432  Edimax Computer Co.
 	9130  RTL81xx Fast Ethernet
 1433  Eltec Elektronik GmbH
+	0002  XRD_FG (PCGR-200) [95510214H]
+	0006  XRD_FGx Opto (PCGR-300) [95510215H]
 # Nee Real Time Devices US Inc.
 1435  RTD Embedded Technologies, Inc.
 	4520  PCI4520
@@ -20379,7 +20765,6 @@
 144c  Catalina Research Inc
 144d  Samsung Electronics Co Ltd
 	1600  S4LN053X01 AHCI SSD Controller(Apple slot)
-	9602  RS780/RS880 PCI to PCI bridge (int gfx)
 	a544  Exynos 8890 PCIe Root Complex
 	a575  Exynos 7420 PCIe Root Complex
 	a5e3  Exynos 5433 PCIe Root Complex
@@ -20389,21 +20774,13 @@
 		144d a801  PM963 2.5" NVMe PCIe SSD
 	a804  NVMe SSD Controller SM961/PM961/SM963
 		144d a801  SM963 2.5" NVMe PCIe SSD
-	a806  NVMe SSD SM0032L
+	a806  PM971 BGA PCIe x2 NVMe SSD
 	a808  NVMe SSD Controller SM981/PM981/PM983
 # Used by different variants of SSD 970 EVO and PRO
 		144d a801  SSD 970 EVO/PRO
 		1d49 403b  Thinksystem U.2 PM983 NVMe SSD
 	a809  NVMe SSD Controller 980 (DRAM-less)
 	a80a  NVMe SSD Controller PM9A1/PM9A3/980PRO
-		0128 215a  DC NVMe PM9A3 RI U.2 960GB
-		0128 215b  DC NVMe PM9A3 RI U.2 1.92TB
-		0128 215c  DC NVMe PM9A3 RI U.2 3.84TB
-		0128 215d  DC NVMe PM9A3 RI U.2 7.68TB
-		0128 2166  DC NVMe PM9A3 RI 110M.2 960GB
-		0128 2167  DC NVMe PM9A3 RI 110M.2 1.92TB
-		0128 2168  DC NVMe PM9A3 RI 80M.2 480GB
-		0128 2169  DC NVMe PM9A3 RI 80M.2 960GB
 		1028 215a  DC NVMe PM9A3 RI U.2 960GB
 		1028 215b  DC NVMe PM9A3 RI U.2 1.92TB
 		1028 215c  DC NVMe PM9A3 RI U.2 3.84TB
@@ -20420,6 +20797,7 @@
 # Actually 88SS1322 according to techpowerup
 	a80b  NVMe SSD Controller PM9B1 (DRAM-less)
 	a80c  NVMe SSD Controller S4LV008[Pascal]
+		144d a801  SSD 990 PRO
 	a80d  NVMe SSD Controller PM9C1a (DRAM-less)
 	a80e  NVMe SSD Controller PM9D3a
 	a80f  BM9C1 QLC NVME SSD (DRAM-less)
@@ -20551,31 +20929,31 @@
 		1028 230f  DC NVMe PM9D3a RI 80M.2 480GB ISE
 		1028 2310  DC NVMe PM9D3a RI 80M.2 960GB ISE
 		1028 2311  DC NVMe PM9D3a RI 80M.2 1.92TB ISE
-		1028 2341  DC NVMe PM9D3a RI U.2 960GB　
+		1028 2341  DC NVMe PM9D3a RI U.2 960GB
 		1028 2342  DC NVMe PM9D3a RI U.2 1.92TB
 		1028 2343  DC NVMe PM9D3a RI U.2 3.84TB
-		1028 2344  DC NVMe PM9D3a RI U.2 7.68GTB
+		1028 2344  DC NVMe PM9D3a RI U.2 7.68TB
 		1028 2345  DC NVMe PM9D3a RI U.2 15.36TB
 		1028 2346  DC NVMe FIPS PM9D3a RI U.2 960GB
 		1028 2347  DC NVMe FIPS PM9D3a RI U.2 1.92TB
 		1028 2348  DC NVMe FIPS PM9D3a RI U.2 3.84TB
 		1028 2349  DC NVMe FIPS PM9D3a RI U.2 7.68TB
-		1028 234a  DC NVMe FIPS PM9D3a RI U.2 15.36TB　
-		1028 234d  DC NVMe PM9D3a RI E3s 1.92TB
-		1028 234e  DC NVMe PM9D3a RI E3s 3.84TB　
-		1028 234f  DC NVMe PM9D3a RI E3s 7.68GTB
-		1028 2350  DC NVMe PM9D3a RI E3s 15.36TB
-		1028 2351  DC NVMe FIPS PM9D3a RI E3s 1.92TB
-		1028 2352  DC NVMe FIPS PM9D3a RI E3s 3.84TB
-		1028 2353  DC NVMe FIPS PM9D3a RI E3s 7.68TB
-		1028 2354  DC NVMe FIPS PM9D3a RI E3s 15.36TB
+		1028 234a  DC NVMe FIPS PM9D3a RI U.2 15.36TB
+		1028 234d  DC NVMe PM9D3a RI E3.S 1.92TB
+		1028 234e  DC NVMe PM9D3a RI E3.S 3.84TB
+		1028 234f  DC NVMe PM9D3a RI E3.S 7.68TB
+		1028 2350  DC NVMe PM9D3a RI E3.S 15.36TB
+		1028 2351  DC NVMe FIPS PM9D3a RI E3.S 1.92TB
+		1028 2352  DC NVMe FIPS PM9D3a RI E3.S 3.84TB
+		1028 2353  DC NVMe FIPS PM9D3a RI E3.S 7.68TB
+		1028 2354  DC NVMe FIPS PM9D3a RI E3.S 15.36TB
 		1028 2355  DC NVMe PM9D5a MU U.2 800GB
 		1028 2356  DC NVMe PM9D5a MU U.2 1.6TB
 		1028 2357  DC NVMe PM9D5a MU U.2 3.2TB
 		1028 2358  DC NVMe PM9D5a MU U.2 6.4TB
-		1028 2359  DC NVMe PM9D5a MU E3.s 1.6TB
-		1028 235a  DC NVMe PM9D5a MU E3.s 3.2TB
-		1028 235b  DC NVMe PM9D5a MU E3.s 6.4TB
+		1028 2359  DC NVMe PM9D5a MU E3.S 1.6TB
+		1028 235a  DC NVMe PM9D5a MU E3.S 3.2TB
+		1028 235b  DC NVMe PM9D5a MU E3.S 6.4TB
 	aa00  NVMe SSD Controller BM1743
 		1028 2312  NVMe FIPS BM1743 QLC U.2 15.36TB
 		1028 2313  NVMe FIPS BM1743 QLC U.2 30.72TB
@@ -20587,6 +20965,56 @@
 		1028 2366  MZ3MO15THCLCAD3
 		1028 2367  MZ3MO30THCLFAD3
 	ac00  NVMe SSD Controller PM175x
+# NVMe FIPS PM1753 RI E3.S 1.92TB
+		1028 2383  MZ3L91T9HFJAAD9
+# NVMe PM1753 RI E3.S 1.92TB
+		1028 2384  MZ3L91T9HFJAAD3
+# NVMe FIPS PM1753 RI E3.S 3.84TB
+		1028 2385  MZ3L93T8HFJAAD9
+# NVMe PM1753 RI E3.S 3.84TB
+		1028 2386  MZ3L93T8HFJAAD3
+# NVMe FIPS PM1753 RI E3.S 7.68TB
+		1028 2387  MZ3L97T6HFLTAD9
+# NVMe PM1753 RI E3.S 7.68TB
+		1028 2388  MZ3L97T6HFLTAD3
+# NVMe FIPS PM1753 RI E3.S 15.36TB
+		1028 2389  MZ3L915THBLCAD9
+# NVMe PM1753 RI E3.S 15.36TB
+		1028 238a  MZ3L915THBLCAD3
+# NVMe FIPS PM1753 RI E3.S 30.72TB
+		1028 238b  MZ3L930THBLFAD9
+# NVMe PM1753 RI E3.S 30.72TB
+		1028 238c  MZ3L930THBLFAD3
+# NVMe FIPS PM1755 MU E3.S 1.6TB
+		1028 238d  MZ3L91T6HFJAAD9
+# NVMe PM1755 MU E3.S 1.6TB
+		1028 238e  MZ3L91T6HFJAAD3
+# NVMe FIPS PM1755 MU E3.S 3.2TB
+		1028 238f  MZ3L93T2HFJAAD9
+# NVMe PM1755 MU E3.S 3.2TB
+		1028 2390  MZ3L93T2HFJAAD3
+# NVMe FIPS PM1755 MU E3.S 6.4TB
+		1028 2391  MZ3L96T4HFLTAD9
+# NVMe PM1755 MU E3.S 6.4TB
+		1028 2392  MZ3L96T4HFLTAD3
+# NVMe PM1753 RI U.2 1.92TB
+		1028 2394  MZWL91T9HFJAAD3
+# NVMe PM1753 RI U.2 3.84TB
+		1028 2396  MZWL93T8HFLTAD3
+# NVMe PM1753 RI U.2 7.68TB
+		1028 2398  MZWL97T6HFLAAD3
+# NVMe PM1753 RI U.2 15.36TB
+		1028 239a  MZWL915THBLFAD3
+# NVMe FIPS PM1753 RI U.2 30.72TB
+		1028 239b  MZWL930THBLFAD9
+# NVMe PM1753 RI U.2 30.72TB
+		1028 239c  MZWL930THBLFAD3
+# NVMe PM1755 MU U.2 1.6TB
+		1028 239e  MZWL91T6HFJAAD3
+# NVMe PM1755 MU U.2 3.2TB
+		1028 239f  MZWL93T2HFLTAD3
+# NVMe PM1755 MU U.2 6.4TB
+		1028 23a0  MZWL96T4HFLAAD3
 	ecec  Exynos 8895 PCIe Root Complex
 144e  OLITEC
 144f  Askey Computer Corp.
@@ -20619,10 +21047,6 @@
 	f436  AVerTV Hybrid+FM
 1462  Micro-Star International Co., Ltd. [MSI]
 	3483  MSI USB 3.0 (VIA VL80x-based xHCI USB Controller)
-# This is MSI refreshed variant of their MECH series Navi 23 GPU card (73EF)
-	5027  RX 6650XT MECH 2X
-	7c56  Realtek Ethernet controller RTL8111H
-	aaf0  Radeon RX 580 Gaming X 8G
 1463  Fast Corporation
 1464  Interactive Circuits & Systems Ltd
 1465  GN NETTEST Telecom DIV.
@@ -20671,8 +21095,6 @@
 148a  OPTO
 148b  INNOMEDIALOGIC Inc.
 148c  Tul Corporation / PowerColor
-	2391  Radeon RX 590 [Red Devil]
-	2398  AXRX 5700 XT 8GBD6-3DHE/OC [PowerColor Red Devil Radeon RX 5700 XT]
 148d  DIGICOM Systems, Inc.
 	1003  HCF 56k Data/Fax Modem
 148e  OSI Plus Corporation
@@ -20799,15 +21221,23 @@
 # MT7612E too?
 	7662  MT7662E 802.11ac PCI Express Wireless Network Adapter
 	7663  MT7663 802.11ac PCI Express Wireless Network Adapter
-	7915  MT7915E 802.11ax PCI Express Wireless Network Adapter
-	7916  MT7905D/MT7975
+	7902  MT7902 802.11ax PCIe Wireless Network Adapter [Filogic 310]
+	7906  MT7916A/MT7916D normal link PCIe Wi-Fi 6(802.11ax) 160MHz 2x2 Wireless Network Adapter [Filogic 630]
+	7915  MT7915A/MT7915D normal link PCIe Wi-Fi 6(802.11ax) 80MHz 4x4/2x2 Wireless Network Adapter [Filogic 615]
+# MT7905D/MT7975 contain MT7915. If it works at G1 speed this extra device appears for extra bandwidth
+	7916  MT7915A/MT7915D hif link PCIe Wi-Fi 6(802.11ax) 80MHz 4x4/2x2 Wireless Network Adapter [Filogic 615]
 # WiFi 6E capable
 	7922  MT7922 802.11ax PCI Express Wireless Network Adapter
 		1a3b 5300  ASUS PCE-AXE59BT
-	7961  MT7921 802.11ax PCI Express Wireless Network Adapter
+	7925  MT7925 802.11be 160MHz 2x2 PCIe Wireless Network Adapter [Filogic 360]
+	7927  MT7927 802.11be 320MHz 2x2 PCIe Wireless Network Adapter [Filogic 380]
+	7961  MT7921 802.11ax PCIe Wireless Network Adapter [Filogic 330]
 	7988  MT7988 PCI Express Host Bridge [Filogic 880]
-	7990  MT7996 802.11be PCI Express Wireless Network Adapter (Port 0)
-	7991  MT7996 802.11be PCI Express Wireless Network Adapter (Port 1)
+	7990  MT7996 primary link PCIe Wi-Fi 7(802.11be) 320MHz Wireless Network Adapter [Filogic 680]
+	7991  MT7996 secondary link PCIe Wi-Fi 7(802.11be) 320MHz Wireless Network Adapter [Filogic 680]
+	7992  MT7992 primary link PCIe Wi-Fi 7(802.11be) 160MHz Wireless Network Adapter [Filogic 660]
+	799a  MT7992 secondary link PCIe Wi-Fi 7(802.11be) 160MHz Wireless Network Adapter [Filogic 660]
+	8188  MT8188 [Kompanio 838] Root Complex
 	8650  MT7650 Bluetooth
 14c4  IWASAKI Information Systems Co Ltd
 14c5  Automation Products AB
@@ -21346,6 +21776,7 @@
 		193d 1087  NIC-ETH531F-3S-2P
 	16d7  BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller
 		117c 00cc  FastFrame N422 Dual-port 25Gb Ethernet Adapter
+		117c 40d7  ThunderLink NS 5252 Dual-port 25Gb Ethernet Adapter
 		14e4 1402  BCM957414A4142CC 10Gb/25Gb Ethernet PCIe
 		14e4 1404  BCM957414M4142C OCP 2x25G Type1 wRoCE
 		14e4 4140  NetXtreme E-Series Advanced Dual-port 25Gb SFP28 Network Daughter Card
@@ -21417,7 +21848,7 @@
 		17aa 3a23  IdeaPad S10e
 	1750  BCM57508 NetXtreme-E 10Gb/25Gb/40Gb/50Gb/100Gb/200Gb Ethernet
 		117c 00cf  FastFrame N412 Dual-port 100Gb Ethernet Adapter
-		117c 40d6  ThunderLink TLNS-5102 Dual-port 100Gb Ethernet Adapter
+		117c 40d6  ThunderLink NS 5102 Dual-port 100Gb Ethernet Adapter
 		14e4 2100  NetXtreme-E Dual-port 100G QSFP56 Ethernet PCIe4.0 x16 Adapter (BCM957508-P2100G)
 		14e4 5208  NetXtreme-E Dual-port 100G QSFP56 Ethernet OCP 3.0 Adapter (BCM957508-N2100G)
 		14e4 520a  NetXtreme-E Dual-port 100G DSFP Ethernet OCP 3.0 Adapter (BCM957508-N2100GD)
@@ -21428,6 +21859,7 @@
 		1028 09d4  PowerEdge XR11/XR12 LOM
 		1028 0b1b  PowerEdge XR5610 LOM
 		117c 00da  FastFrame N424 Quad-port 25Gb Ethernet Adapter
+		117c 40df  ThunderLink NS 5254 Quad-port 25Gb Ethernet Adapter
 		14e4 4250  NetXtreme-E Quad-port 25G SFP28 Ethernet PCIe4.0 x16 Adapter (BCM957504-P425G)
 		14e4 5045  NetXtreme-E BCM57504 4x25G OCP3.0
 		14e4 5100  NetXtreme-E Single-port 100G QSFP56 Ethernet OCP 3.0 Adapter (BCM957504-N1100G)
@@ -21438,6 +21870,7 @@
 		1590 0420  HPE Ethernet 25/50Gb 2-port 6310C Adapter
 	1752  BCM57502 NetXtreme-E 10Gb/25Gb/40Gb/50Gb Ethernet
 	1760  BCM57608 25Gb/50Gb/100Gb/200Gb/400Gb Ethernet
+		117c 00cf  FastFrame N522 Dual-port 200Gb Ethernet Adapter
 		14e4 9110  BCM57608 1x400G PCIe Ethernet NIC
 		14e4 9120  BCM57608 2x200G PCIe Ethernet NIC
 		14e4 9121  BCM57608 2x100G PCIe Ethernet NIC
@@ -21453,6 +21886,23 @@
 		14e4 9340  BCM57608 4x100G OCP Ethernet NIC
 		14e4 9345  BCM57608 4x25G OCP Ethernet NIC
 		14e4 d125  BCM57608 2x200G PCIe Ethernet NIC
+		193d 105b  NIC-ETH2030F-LP-2P 2x200G PCIe Ethernet NIC
+		193d 105c  NIC-ETH4030F-LP-1P 1x400G PCIe Ethernet NIC
+	1780  BCM57708 50Gb/100Gb/200Gb/400Gb/800Gb Ethernet
+		14e4 1043  BCM957708 1x800G OCP Ethernet NIC
+		14e4 1143  BCM957708 1x800G OCP Ethernet NIC
+		14e4 1443  BCM957708 1x800G OCP Ethernet NIC
+		14e4 1543  BCM957708 1x800G OCP Ethernet NIC
+		14e4 1843  BCM957708 1x800G OCP Ethernet NIC
+		14e4 1943  BCM957708 1x800G OCP Ethernet NIC
+		14e4 8023  BCM957708 2x400G PCIe Ethernet NIC
+		14e4 8043  BCM957708 1x800G PCIe Ethernet NIC
+		14e4 8123  BCM957708 2x400G PCIe Ethernet NIC
+		14e4 8143  BCM957708 1x800G PCIe Ethernet NIC
+		14e4 9023  BCM957708 2x400G PCIe Ethernet NIC
+		14e4 9043  BCM957708 1x800G PCIe Ethernet NIC
+		14e4 9123  BCM957708 2x400G PCIe Ethernet NIC
+		14e4 9143  BCM957708 1x800G PCIe Ethernet NIC
 	1800  BCM57502 NetXtreme-E Ethernet Partition
 	1801  BCM57504 NetXtreme-E Ethernet Partition
 		1590 0420  Ethernet NPAR 6310C Adapter
@@ -21570,6 +22020,7 @@
 		1154 0330  Buffalo WLI2-PCI-G54S High Speed Mode Wireless Desktop Adapter
 		144f 7050  eMachines M6805 802.11g Built-in Wireless
 		144f 7051  Sonnet Aria Extreme PCI
+		16a5 1604  WE602-B
 		1737 0013  WMP54G v1 802.11g PCI Adapter
 		1737 0014  WMP54G v2 802.11g PCI Adapter
 		1737 0015  WMP54GS v1.0 802.11g Wireless-G PCI Adapter with SpeedBooster
@@ -21661,6 +22112,8 @@
 	43ba  BCM43602 802.11ac Wireless LAN SoC
 	43bb  BCM43602 802.11ac Wireless LAN SoC
 	43bc  BCM43602 802.11ac Wireless LAN SoC
+	43c3  BCM4366/BCM43465 802.11ac Wave2 4x4 Wireless Network Adapter
+		1043 86fb  PCE-AC88
 	43d3  BCM43567 802.11ac Wireless Network Adapter
 	43d9  BCM43570 802.11ac Wireless Network Adapter
 	43dc  BCM4355 802.11ac Wireless LAN SoC
@@ -21686,6 +22139,7 @@
 	4430  BCM44xx CardBus iLine32 HomePNA 2.0
 	4432  BCM4432 CardBus 10/100BaseT
 	4433  BCM4387 802.11ax Dual Band Wireless LAN Controller
+	4434  BCM4388 802.11ax Dual Band Wireless LAN Controller
 	4464  BCM4364 802.11ac Wireless Network Adapter
 # brcmfmac reports it as BCM4377/4 but macOS drivers call it BCM4377b
 	4488  BCM4377b Wireless Network Adapter
@@ -21743,15 +22197,20 @@
 	5f69  BRCM4378 Bluetooth Controller
 # Bluetooth PCI function of the BRCM4387 Wireless Network Adapter
 	5f71  BRCM4387 Bluetooth Controller
+# Bluetooth PCI function of the BCM4388 Wireless Network Adapter
+	5f72  BCM4388 Bluetooth Controller
 # Bluetooth PCI function of the BRCM4377 Wireless Network Adapter
 	5fa0  BRCM4377 Bluetooth Controller
+	6865  BCM68650 [Aspen] XGSPON OLT
 	8411  BCM47xx PCIe Bridge
 	8602  BCM7400/BCM7405 Serial ATA Controller
 	9026  CN99xx [ThunderX2] Integrated USB 3.0 xHCI Host Controller
 	9027  CN99xx [ThunderX2] Integrated AHCI/SATA 3 Host Controller
 	a8d8  BCM43224/5 Wireless Network Adapter
 	aa52  BCM43602 802.11ac Wireless LAN SoC
+	b070  BCM56070 Switch ASIC [Firelight]
 	b080  BCM56080 Firelight2 Switch ASIC
+	b172  BCM56172 Hurricane3-MG
 	b302  BCM56302 StrataXGS 24x1GE 2x10GE Switch Controller
 	b334  BCM56334 StrataXGS 24x1GE 4x10GE Switch Controller
 	b370  BCM56370 Switch ASIC
@@ -21767,6 +22226,7 @@
 	b800  BCM56800 StrataXGS 10GE Switch Controller
 	b842  BCM56842 Trident 10GE Switch Controller
 	b850  BCM56850 Switch ASIC [Trident2]
+	b854  BCM56854 Trident2 switch ASIC
 	b880  BCM56880 Switch ASIC
 	b960  BCM56960 Switch ASIC [Tomahawk]
 	b990  BCM56990 Switch ASIC [Tomahawk4]
@@ -21895,6 +22355,8 @@
 		0e11 0042  Yogi
 # Integrated in CX86111/CX86113 processors
 	1830  CX861xx Integrated Host Bridge
+	1f86  DBH CX11880 Codec
+	1f87  SMIC CX11880 Codec
 	2003  HSF 56k Data/Fax Modem
 	2004  HSF 56k Data/Fax/Voice Modem
 	2005  HSF 56k Data/Fax/Voice/Spkp (w/Handset) Modem
@@ -22264,10 +22726,6 @@
 1539  ATELIER INFORMATIQUES et ELECTRONIQUE ETUDES S.A.
 153a  ONO SOKKI
 153b  TERRATEC Electronic GmbH
-	1144  Aureon 5.1
-# Terratec seems to use several IDs for the same card.
-	1147  Aureon 5.1 Sky
-	1158  Philips Semiconductors SAA7134 (rev 01) [Terratec Cinergy 600 TV]
 153c  ANTAL Electronic
 153d  FILANET Corp
 153e  TECHWELL Inc
@@ -22506,7 +22964,7 @@
 	0224  CX9 Family [ConnectX-9 Flash Recovery]
 	0225  CX9 Family [ConnectX-9 Secure Flash Recovery-RMA]
 	0226  CX10 Family [ConnectX-10 Flash Recovery]
-	0227  CX10 Family [ConnectX-10 Secure Flash Recovery-RMA]
+	0227  CX10 Family [ConnectX-10 RMA]
 	0228  CX9 PCIe Switch Family [ConnectX-9 PCIe Switch Flash Recovery]
 	0229  CX9 PCIe Switch Family [ConnectX-9 PCIe Switch Secure Flash Recovery-RMA]
 	024e  MT53100 [Spectrum-2, Flash recovery mode]
@@ -22533,11 +22991,14 @@
 	0274  Spectrum-6 in Flash Recovery Mode
 	0275  Spectrum-6 RMA
 	0277  Spectrum-6 Tile
-	0278  Quantum-4 in Flash Recovery Mode
-	0279  Quantum-4 RMA
+	0278  NVLink-6 Switch in Flash Recovery Mode
+	0279  NVLink-6 Switch RMA
 	027a  Eros Chiplet
-	027c  Quantum-5 in Flash Recovery Mode
-	027d  Quantum-5 RMA
+	027c  NVLink-7 Switch in Flash Recovery Mode
+	027d  NVLink-7 Switch RMA
+	027e  Spectrum-7 Tile
+# Spectrum-8 tile
+	027f  Spectrum-8 tile
 	0281  NPS-600 Flash Recovery
 	0282  ArcusE Flash recovery
 	0283  ArcusE RMA
@@ -22545,25 +23006,27 @@
 	0285  Sagitta RMA
 	0286  LibraE Flash Recovery
 	0287  LibraE RMA
-# Flash recovery
-	0288  Arcus2
+	0288  Arcus2 Flash Recovery
 	0289  Arcus2 RMA
 	0290  SagittaZ
 	0292  Arcus3 Flash Recovery
 	0293  Arcus3 RMA
-	0294  Ophy 2.1 (SagittaZ)
-# Sagitta
-	0296  OPHY2.6
-# Sagitta
-	0298  OPHY3.0
-# Sagitta
-	029a  OPHY3.1
-# Sagitta
-	029c  OPHY3.5
-	02a0  Quantum-6 in Flash Recovery Mode
-	02a1  Quantum-6 RMA
+	0294  OPHY2.1 [SagittaZ]
+	0296  OPHY2.6 [Sagitta]
+	0298  OPHY3.0 [Sagitta]
+	029a  OPHY3.1 [Sagitta]
+	029c  OPHY3.5 [Sagitta]
+	02a0  NVLink-8 Switch in Flash Recovery Mode
+	02a1  NVLink-8 Switch RMA
 	02a2  Spectrum-7 in Flash Recovery Mode
 	02a3  Spectrum-7 RMA
+# 400G Retimer
+	02a6  OrionR
+	02a7  OrionR RMA
+# Spectrum-8 in Flash Recovery Mode
+	02a8  Spectrum-8 in Flash Recovery Mode
+# Spectrum-8 RMA
+	02a9  Spectrum-8 RMA
 	1002  MT25400 Family [ConnectX-2 Virtual Function]
 	1003  MT27500 Family [ConnectX-3]
 		1014 04b5  PCIe3 40GbE RoCE Converged Host Bus Adapter for Power
@@ -22630,6 +23093,8 @@
 		117c 00b4  FastFrame N322 Dual-port 25Gb Ethernet Adapter
 		117c 40b7  ThunderLink TLN3-3252 Dual-port 25Gb Ethernet Adapter
 		117c 40b8  ThunderLink TLN3-3102 Dual-port 10Gb Ethernet Adapter
+		1458 0280  CLN4C44
+		1458 0281  CLN4C44 with NCSI
 		15b3 0001  ConnectX-4 Lx EN network interface card, 25GbE single-port SFP28, PCIe3.0 x8, tall bracket, ROHS R6
 		15b3 0003  Stand-up ConnectX-4 Lx EN, 25GbE dual-port SFP28, PCIe3.0 x8, MCX4121A-ACAT
 		15b3 0004  ConnectX-4 Lx Stand-up dual-port 10GbE MCX4121A-XCAT
@@ -22682,6 +23147,7 @@
 	1024  CX8 PCIe Switch Family [ConnectX-8 PCIe Switch]
 	1025  CX9 Family [ConnectX-9]
 	1027  CX10 Family [ConnectX-10]
+	1028  CX10 Family [ConnectX-10 Trusted Network Control Memory]
 	1974  MT28800 Family [ConnectX-5 PCIe Bridge]
 	1975  MT416842 Family [BlueField SoC PCIe Bridge]
 	1976  MT28908 Family [ConnectX-6 PCIe Bridge]
@@ -22700,6 +23166,10 @@
 	2024  MT43244 Family [BlueField-3 SoC Emulated PCIe Bridge]
 	2025  ConnectX/BlueField Family mlx5Gen Emulated PCIe Bridge [Emulated PCIe Bridge]
 	2100  CX8 Family [CX8 Data Direct Interface]
+# NVLink Chip to Chip Link
+	2101  CX10 Family [ConnectX-10 NVLink-C2C]
+# Starting with CX10 generation
+	2300  ConnectX/BlueField Family Hardware Performance Monitors [HWPM]
 	4117  MT27712A0-FDCF-AE
 		1bd4 0039  SN10XMP2P25
 		1bd4 003a  25G SFP28 SP EO251FM9 Adapter
@@ -22767,6 +23237,7 @@
 	b201  LibraE
 	b202  Arcus2
 	b203  Arcus3
+	b204  OrionR
 	c2d1  BlueField DPU Family Auxiliary Communication Channel [BlueField Family]
 	c2d2  MT416842 BlueField SoC management interfac
 	c2d3  MT42822 BlueField-2 SoC Management Interface
@@ -22776,12 +23247,15 @@
 # SwitchX-2, 40GbE switch
 	c738  MT51136
 	c739  MT51136 GW
+# Spectrum-8
+	c788  Spectrum-8
 	c838  MT52236
 	c839  MT52236 router
 	caf1  ConnectX-4 CAPI Function
 # Spectrum, 100GbE Switch
 	cb84  MT52100
 	cf08  Switch-IB2
+	cf09  Quantum Aggregation Node
 	cf6c  MT53100 [Spectrum-2]
 	cf70  Spectrum-3
 	cf80  Spectrum-4
@@ -22792,9 +23266,9 @@
 	d2f2  Quantum-2 NDR (400Gbps) switch
 	d2f4  Quantum-3
 	d2f6  Quantum-3CPO
-	d2f8  Quantum-4
-	d2fa  Quantum-5
-	d2fc  Quantum-6
+	d2f8  NVLink-6 Switch
+	d2fa  NVLink-7 Switch
+	d2fc  NVLink-8 Switch
 15b4  CCI/TRIAD
 15b5  Cimetrics Inc
 15b6  Texas Memory Systems Inc
@@ -22822,7 +23296,7 @@
 	5004  PC SN520 x2 M.2 2230 NVMe SSD
 	5005  PC SN520 x2 M.2 2242 NVMe SSD
 	5006  SanDisk Extreme Pro / WD Black SN750 / PC SN730 / Red SN700 NVMe SSD
-	5007  IX SN530 NVMe SSD (DRAM-less)
+	5007  IX SN530 NVMe SSD / microSD Express Card (DRAM-less)
 	5008  PC SN530 NVMe SSD (DRAM-less)
 	5009  SanDisk Ultra 3D / WD PC SN530, IX SN530, Blue SN550 NVMe SSD (DRAM-less)
 		15b7 5009  WD Blue SN550 NVMe SSD
@@ -22848,12 +23322,16 @@
 	5036  WD PC SN5000S M.2 2280 NVMe SSD (DRAM-less)
 	5041  WD Blue SN580 NVMe SSD (DRAM-less)
 	5042  WD Black SN770M NVMe SSD (DRAM-less)
-	5044  WD PC SN7100S NVMe SSD (DRAM-less)
-	5045  WD_BLACK SN7100 NVMe SSD (DRAM-less)
+	5043  WD PC SN7100S M.2 2230 NVMe SSD (DRAM-less)
+	5044  WD PC SN7100S M.2 2242 NVMe SSD (DRAM-less)
+	5045  WD_BLACK SN7100/WD PC SN7100S M.2 2280 NVMe SSD (DRAM-less)
 	5046  SanDisk Extreme NVMe SSD (DRAM-less)
 	5049  SN8000S NVMe SSD
 	504a  WD Blue SN5000 NVMe SSD (DRAM-less)
 	5050  WD PC SN8050S / WD_BLACK SN8100 NVMe SSD
+	5061  PC SN5100S M.2 2230 NVMe SSD (DRAM-less)
+	5062  PC SN5100S M.2 2242 NVMe SSD (DRAM-less)
+	5063  PC SN5100S / WD Blue SN5100 M.2 2280 NVMe SSD (DRAM-less)
 15b8  ADDI-DATA GmbH
 	1001  APCI1516 SP controller (16 digi outputs)
 	1003  APCI1032 SP controller (32 digi inputs w/ opto coupler)
@@ -22909,6 +23387,8 @@
 15ce  Genrad Inc
 15cf  Hilscher Gesellschaft für Systemautomation mbH
 	0000  CIFX PCI/PCIe
+	0090  CIFX PCIe
+	0900  CIFX PCIe
 15d1  Infineon Technologies AG
 15d2  FIC (First International Computer Inc)
 15d3  NDS Technologies Israel Ltd
@@ -22918,9 +23398,6 @@
 15d7  Rockwell-Collins Inc
 15d8  Cybernetics Technology Co Ltd
 15d9  Super Micro Computer Inc
-	1b64  SCC-B8SB80-B1
-	1b9d  Supermicro AOC-S3816L-L16IR
-	1c6e  Supermicro AOC-SLG4-2H8M2
 15da  Cyberfirm Inc
 15db  Applied Computing Systems Inc
 15dc  Litronic Inc
@@ -23167,8 +23644,6 @@
 167e  ONNTO Corp.
 1681  Hercules
 1682  XFX Pine Group Inc.
-	5701  Radeon 5700 XT Thicc III Ultra
-	c580  Radeon RX 580
 1688  CastleNet Technology Inc.
 	1170  WLAN 802.11b card
 168a  Utimaco IS GmbH
@@ -23181,9 +23656,14 @@
 # nee Atheros Communications, Inc.
 168c  Qualcomm Atheros
 	0007  AR5210 Wireless Network Adapter [AR5000 802.11a]
+		1186 3a00  DWL-A650 5GHz Wireless CardBus Adapter
+		1186 3a02  DWL-A520 5GHz Wireless PCI Adapter
+		1668 0429  802CA Wireless PC Card
 		1737 0007  WPC54A Wireless PC Card
 		1b47 0100  Harmony 8450CN Wireless CardBus Module
 		1b47 0110  Skyline 4030 / Harmony 8450 802.11a Wireless CardBus Adapter
+		1b47 0400  PC50E-8-FC/A Wireless Access Point Radio Card
+		8086 2500  PRO/Wireless 5000 LAN CardBus Adapter
 		8086 2501  PRO/Wireless 5000 LAN PCI Adapter Module
 	0011  AR5211 Wireless Network Adapter [AR5001A 802.11a]
 	0012  AR5211 Wireless Network Adapter [AR5001X 802.11ab]
@@ -23324,6 +23804,7 @@
 		1186 3a67  DWL-G650M Super G MIMO Wireless Notebook Adapter
 		1186 3a68  DWL-G520M Wireless 108G MIMO Desktop Adapter
 		187e 340e  M-302 802.11g Wireless PCI Adapter
+		1976 1600  TEW-603PI 108Mbps 802.11g Wireless PCI Adapter
 		1976 2003  TEW-601PC 802.11g Wireless CardBus Adapter
 	0023  AR5416 Wireless Network Adapter [AR5008 802.11(a)bgn]
 		0308 340b  NWD-170N 802.11bgn Wireless CardBus Adapter
@@ -23341,7 +23822,10 @@
 		1976 2008  TEW-621PC 802.11bgn Wireless CardBus Adapter
 	0024  AR5418 Wireless Network Adapter [AR5008E 802.11(a)bgn] (PCI-Express)
 		106b 0087  AirPort Extreme
+		1154 0366  WLP-EXC-AG300 802.11abgn ExpressCard
+		1186 3a6f  DWA-643 Xtreme N Notebook ExpressCard
 		1186 3a70  DWA-556 Xtreme N PCI Express Desktop Adapter
+		1799 8071  F5D8071 v1 N1 Wireless ExpressCard
 	0027  AR9160 Wireless Network Adapter [AR9001 802.11(a)bgn]
 		0777 4082  SR71-A 802.11abgn Wireless Mini PCI Adapter
 	0029  AR922X Wireless Network Adapter
@@ -23678,8 +24162,10 @@
 	7174  VSC7174 PCI/PCI-X Serial ATA Host Bus Controller
 172a  Accelerated Encryption
 	13c8  AEP SureWare Runner 1000V3
+172f  Sparkle Computer Co., Ltd.
 # nee Fujitsu Siemens Computers GmbH
 1734  Fujitsu Technology Solutions
+	1228  iRMC-S5 HTI Device
 	9602  RS780/RS880 PCI to PCI bridge (int gfx)
 1735  Aten International Co. Ltd.
 1737  Linksys
@@ -23747,6 +24233,22 @@
 	0843  PCA-8439 General-purpose multifunctional PCIe card with 16 analog inputs
 	ff00  CTU CAN FD PCIe Card
 1761  Pickering Interfaces Ltd
+	4411  Pickering Devices with FPGA Based Bus Communication
+		1761 082f  40-737-901
+		1761 086c  40-576-001
+		1761 0881  40-584-001
+		1761 311a  42-738-001
+		1761 3190  41-765-004
+		1761 31ab  41-670-003
+		1761 331f  50-297A-014
+		1761 3320  50-297A-050
+		1761 3321  50-297A-056
+		1761 3366  41-625-004
+		1761 3368  50-297A-130
+		1761 3372  50-297A-122
+		1761 33a1  40-419-004
+		1761 33a3  41-770-002
+		1761 3714  42-297A-050
 1771  InnoVISION Multimedia Ltd.
 1775  General Electric
 177d  Cavium, Inc.
@@ -23876,6 +24378,8 @@
 	a300  OCTEON TX CN83XX
 	af00  CN99xx [ThunderX2] Integrated PCI Host bridge
 	af84  CN99xx [ThunderX2] Integrated PCI Express RP Bridge
+# Name inferred from https://www.prnewswire.com/news-releases/cavium-and-xpliant-introduce-a-fully-programmable-switch-silicon-family-scaling-to-32-terabits-per-second-275262511.html
+	f010  XPliant CNX880xx Network Processor
 1787  Hightech Information System Ltd.
 1789  Ennyah Technologies Corp.
 # also used by Struck Innovative Systeme for joint developments
@@ -23951,7 +24455,7 @@
 	8084  GL880 USB 2.0 EHCI controller
 	9750  GL9750 SD Host Controller
 	9755  GL9755 SD Host Controller
-	9767  GL9767 SD Host Controller
+	9767  GL9767 PCIe SD UHS-II & SD Express Card Reader Controller
 	e763  GL9763E eMMC Controller
 17aa  Lenovo
 	0003  LENSE20256GMSP34MEAT2TA
@@ -23977,11 +24481,16 @@
 # nee Airgo Networks, Inc.
 17cb  Qualcomm Technologies, Inc
 	0001  AGN100 802.11 a/b/g True MIMO Wireless Card
+		1154 0337  WLI-CB-G108
 		1385 5c00  WGM511 Pre-N 802.11g Wireless CardBus Adapter
+		14ea 6101  CQW-NS108G
+		1737 0037  WPC54GX Wireless-G Notebook Adapter with SRX
 		1737 0045  WMP54GX v1 802.11g Wireless-G PCI Adapter with SRX
 	0002  AGN300 802.11 a/b/g True MIMO Wireless Card
+		1043 106f  WL-106gM 240 MIMO Wireless CardBus Adapter
 		1385 6d00  WPNT511 RangeMax 240 Mbps Wireless CardBus Adapter
 		1737 0054  WPC54GX4 v1 802.11g Wireless-G Notebook Adapter with SRX400
+		1737 0056  WMP54GX4 Wireless-G PCI Adapter with SRX400
 	0104  APQ8096 PCIe Root Complex [Snapdragon 820]
 	0105  MSM8998 PCIe Root Complex
 	0106  SDM850 PCIe Root Complex [Snapdragon 850]
@@ -23999,6 +24508,28 @@
 	0302  MDM9x55 LTE Modem [Snapdragon X16]
 	0304  SDX24 [Snapdragon X24 4G]
 	0306  SDX55 [Snapdragon X55 5G]
+	0308  SDX61/SDX62/SDX65 [Snapdragon 5G X6X-series]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e142  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e143  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e144  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e145  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e146  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e150  T99W696 5G Modem [Snapdragon X61]
+		105b e151  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e152  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e153  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e154  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e155  T99W696 5G Modem [Snapdragon X61]
 	0400  Datacenter Technologies QDF2432 PCI Express Root Port
 	0401  Datacenter Technologies QDF2400 PCI Express Root Port
 	1000  QCS405 PCIe Root Complex
@@ -24014,6 +24545,12 @@
 	2280  NET2280 PCI to USB 2.0 Hi-Speed Peripheral Controller
 	2282  NET2282 PCI to USB 2.0 Hi-Speed Peripheral Controller
 17cd  Cadence Design Systems, Inc.
+	0100  CIX PCIe Root Port
+	dc01  Phytium PCIe 3.0 x1 Root Complex
+	dc08  Phytium PCIe 3.0 x8 Root Complex
+	dc16  Phytium PCIe 3.0 x8 Root Complex
+	fc01  Phytium PCIe 3.0 x1 Root Complex
+	fc16  Phytium PCIe 3.0 x8/x16 Root Complex
 17cf  Z-Com, Inc.
 17d3  Areca Technology Corp.
 	1110  ARC-1110 4-Port PCI-X to SATA RAID Controller
@@ -24204,6 +24741,7 @@
 	2120  IPN 2120 802.11b
 		1737 0020  WMP11 v4 802.11b Wireless-B PCI Adapter
 	2220  IPN 2220 802.11g
+		1154 0334  WLI2-CB-G54L
 		1468 0305  T60N871 802.11g Mini PCI Wireless Adapter
 		1737 0029  WPC54G v4 802.11g Wireless-G Notebook Adapter
 17ff  Benq Corporation
@@ -24279,15 +24817,18 @@
 	0301  RT2561/RT61 802.11g PCI
 		1186 3c08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.E1)
 		1186 3c09  DWL-G510 Rev C
+		1259 c123  CG-WLCB54GPX
 		13d1 abe3  miniPCI Pluscom 802.11 a/b/g
 		1458 e933  GN-WI01GS
 		1458 e934  GN-WP01GS
 		1462 b833  MP54G5 (MS-6833B)
+		1462 b834  PC60G (MS-6834B) Wireless 11g Turbo G PCI Card
 		1737 0055  WMP54G v4.1
 		1799 700e  F5D7000 v6000 Wireless G Desktop Card
 		1799 701e  F5D7010 v6000 Wireless G Notebook Card
 		17f9 0012  AWLC3026T 802.11g Wireless CardBus Adapter
 		1814 2561  EW-7108PCg/EW-7128g
+		182d 90aa  WL-170 Wireless Network Cardbus Card
 	0302  RT2561/RT61 rev B 802.11g
 		1186 3a71  DWA-510 Wireless G Desktop Adapter
 		1186 3c08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.E2)
@@ -24304,11 +24845,15 @@
 		187e 3412  NWD-310N 802.11n Wireless PCI Adapter
 	0681  RT2890 Wireless 802.11n PCIe
 		1458 e939  GN-WS30N-RH 802.11bgn Mini PCIe Card
+		1799 8073  F5D8073 v1 N Wireless ExpressCard Adapter
+		1799 807c  F5D8071 v3 N1 Wireless ExpressCard
 	0701  RT2760 Wireless 802.11n 1T/2R
 		1737 0074  WMP110 v2 802.11n RangePlus Wireless PCI Adapter
 	0781  RT2790 Wireless 802.11n 1T/2R PCIe
 		11ad 7600  HP WN7600R
+		1799 817c  F5D8073 v3 N Wireless ExpressCard Adapter
 		1814 2790  RT2790 Wireless 802.11n 1T/2R PCIe
+		1976 2600  TEW-642EC Wireless N ExpressCard
 	3060  RT3060 Wireless 802.11n 1T/1R
 		1186 3c04  DWA-525 Wireless N 150 Desktop Adapter (rev.A1)
 	3062  RT3062 Wireless 802.11n 2T/2R
@@ -24360,6 +24905,7 @@
 	08b0  MVC200-DC
 1846  Alcatel-Lucent
 1849  ASRock Incorporation
+	1150  ASPEED AST1150 PCI-to-PCI Bridge
 	9602  RS780/RS880 PCI to PCI bridge (int gfx)
 184a  Thales Computers
 	1100  MAX II cPLD
@@ -24394,8 +24940,6 @@
 	a102  VigraWATCH PMC
 	a103  Vigra I/O
 187e  ZyXEL Communications Corporation
-	3403  ZyAir G-110 802.11g
-	340e  M-302 802.11g XtremeMIMO
 1885  Avvida Systems Inc.
 1888  Varisys Ltd
 	0301  VMFX1 FPGA PMC module
@@ -24599,6 +25143,7 @@
 # since the merger with NEC Electronics in 2010
 1912  Renesas Electronics Corp.
 	0002  SH7780 PCI Controller (PCIC)
+	0004  SH7763 PCI Controller (PCIC)
 	0011  SH7757 PCIe End-Point [PBI]
 	0012  SH7757 PCIe-PCI Bridge [PPB]
 	0013  SH7757 PCIe Switch [PS]
@@ -24608,6 +25153,7 @@
 	001a  SH7758 PCIe-PCI Bridge [PPB]
 	001b  SH7758 PCIe End-Point [PBI]
 	001d  SH7758 PCIe Switch [PS]
+	0033  RZ/G3S PCIe 2.0 Controller
 1919  Soltek Computer Inc.
 1923  Sangoma Technologies Corp.
 	0040  A200/Remora FXO/FXS Analog AFT card
@@ -25015,7 +25561,10 @@
 	5021  PS5021-E21 PCIe4 NVMe Controller (DRAM-less)
 	5026  PS5026-E26 PCIe5 NVMe Controller
 	5027  PS5027-E27T PCIe4 NVMe Controller (DRAM-less)
+	5028  PS5028-E28 PCIe5 NVMe Controller
+	5029  PS5029-E29T PCIe4 NVMe Controller (DRAM-less)
 	5031  PS5031-E31T PCIe5 NVMe Controller
+	5037  PS5037-E37T PCIe5 NVMe Controller (DRAM-less)
 	5302  PS5302-X2 PCIe5 NVMe Controller
 1989  Montilio Inc.
 	0001  RapidFile Bridge
@@ -25023,6 +25572,12 @@
 198a  Nallatech Ltd.
 1993  Innominate Security Technologies AG
 1998  Toyou Feiji Electronics Co., Ltd.
+	0001  TOBOLT1 51987 NVMe SSD
+		1998 0192  TOBOLT1 45967 1920G M.2 NVMe SSD
+		1998 0384  TOBOLT1 51987 3840G 2.5" U.2 NVMe SSD
+		1998 0768  TOBOLT1 51987 7680G 2.5" U.2 NVMe SSD
+		1998 2012  TOBOLT1 51987 3840G 2.5" U.2 NVMe SSD
+		1998 6144  TOBOLT1 51995 6144G 2.5" U.2 NVMe SSD
 1999  A-Logics
 	a900  AM-7209 Video Processor
 199a  Pulse-LINK, Inc.
@@ -25135,16 +25690,25 @@
 		19e5 0051  Hi1822 SP681 (2*25/10GE)
 		19e5 0052  Hi1822 SP680 (4*25/10GE)
 		19e5 00a1  Hi1822 SP670 (2*100GE)
+		19e5 0152  Hi1822 SP623Q (4*25/10GE)
+		19e5 01a1  Hi1822 SP625D (2*100GE)
+	0229  Hi1872 Family
+	022a  Hi1872 Family Virtual Function
+	0230  Hi1825 Family
+	0231  Hi1825 Family Virtual Function
 	1710  iBMA Virtual Network Adapter
 	1711  Hi171x Series [iBMC Intelligent Management system chip w/VGA support]
+	1712  Intelligent Management system chip Virtual Network Adapter
 	1822  Hi1822 Family (4*25GE)
 		19e5 d129  Hi1822 SP570 (4*25GE)
 		19e5 d136  Hi1822 SP580 (4*25GE)
 		19e5 d141  Hi1822 SP583 (4*25GE)
 		19e5 d146  Hi1822 SP585 (4*25GE)
+	36f0  Intelligent Management system chip SATA AHCI support
 	3714  ES3000 V5 NVMe PCIe SSD
 		19e5 5312  NVMe SSD ES3500P V5 2000GB 2.5" U.2
 	371e  Hi1822 Family Virtual Bridge
+	3730  Intelligent Management system chip GE support
 	3754  ES3000 V6 NVMe PCIe SSD
 		19e5 6122  NVMe SSD ES3600P V6 1600GB 2.5" U.2
 		19e5 6123  NVMe SSD ES3600P V6 3200GB 2.5" U.2
@@ -25163,14 +25727,18 @@
 		19e5 01ad  RAID SP686C-M-40i 4G
 	375e  Hi1822 Family Virtual Function
 	375f  Hi1822 Family Virtual Function
+	3770  Intelligent Management system chip Virtual Feature USB2.0 HOST support
 	379e  Hi1822 Family Virtual Function
 	379f  Hi1822 Family Virtual Function
+	37b0  Intelligent Management system chip USB3.0 HOST support
+	37f0  Intelligent Management system chip USB2.0 HOST support
+	3830  Intelligent Management system chip Memory-Mapped Buffer Interface
 	3858  SP186 HBA Controller Card
 		19e5 0120  HBA SP186-M-32i
 		19e5 0125  HBA SP186-M-40i
 		19e5 0180  HBA SP186-M-16i
 		19e5 0188  HBA SP186-M-8i
-	a120  HiSilicon PCIe Root Port with Gen4
+	a120  HiSilicon PCIe Root Port
 	a121  HiSilicon PCI-PCI Bridge
 	a122  HiSilicon Embedded DMA Engine
 	a124  HiSilicon Internal SDI Function Engine
@@ -25178,8 +25746,10 @@
 	a126  HiSilicon SDI NVMe Storage Controller
 	a127  HiSilicon SDI Accelerator
 	a12a  HiSilicon Add-on PCI-PCI Bridge
+	a12c  HiSilicon Embedded PCIe DFX
 	a12d  HiSilicon Embedded PMU
 	a12e  HiSilicon Embedded PCIe PTT
+	a12f  HiSilicon DFX Registers
 	a220  HNS GE Network Controller
 	a221  HNS GE/10GE/25GE Network Controller
 		19e5 0454  TM280
@@ -25214,13 +25784,22 @@
 	1005  STIX - 4 Port FXS Card
 19ee  Netronome Systems, Inc.
 19f1  BFG Tech
+19fe  ESI Audiotechnik GmbH
+	7000  MAYA44 family PCI Audio Controller
 19ff  Eclipse Electronic Systems, Inc.
 1a03  ASPEED Technology, Inc.
 	1150  AST1150 PCI-to-PCI Bridge
-	2000  ASPEED Graphics Family
 		15d9 0821  X10DRW-i
-		15d9 0832  X10SRL-F
-		15d9 1b95  H12SSL-i
+		15d9 086b  X10DRS
+		15d9 1d50  X14DBG-AP
+	2000  ASPEED Graphics Family
+		15d9 0821  X10DRW-i (AST2400 BMC)
+		15d9 0832  X10SRL-F (AST2400 BMC)
+		15d9 086b  X10DRS (AST2400 BMC)
+		15d9 086d  X10SDV (AST2400 BMC)
+		15d9 1b95  H12SSL-i (AST2500 BMC)
+		15d9 1d50  X14DBG-AP (AST2600 BMC)
+		1849 2000  Onboard Graphics
 1a05  deltaww
 1a07  Kvaser AB
 	0006  CAN interface PC104+ HS/HS
@@ -25279,7 +25858,7 @@
 	0200  TILE-Gx processor
 	0201  TILE-Gx Processor Virtual Function
 	2000  TILE-Gx PCI Express Root Port
-1a4a  SLAC National Accelerator Lab TID-AIR
+1a4a  SLAC National Accelerator Lab TID-ID
 	1000  MCOR Power Supply Controller
 	1010  AMC EVR - Stockholm Timing Board
 	1020  PGPCard - Gen3 Cameralink Interface
@@ -25290,6 +25869,28 @@
 	2011  PCI-Express EVR - TPR Version
 	2020  PGP-GEN3 PCIe - 8 Lane Plus EVR
 	2030  AXI Stream DAQ PCIe card
+		1022 0005  Xilinx AC701
+		1022 0006  Xilinx Alveo U50
+		1022 0007  Xilinx Alveo U200
+		1022 0008  Xilinx Alveo U250
+		1022 0009  Xilinx Alveo U280
+		1022 000a  Xilinx KC705
+		1022 000b  Xilinx KCU105
+		1022 000c  Xilinx KCU116
+		1022 000d  Xilinx KCU1500
+		1022 000e  Xilinx VCU128
+		1022 000f  Xilinx Alveo U55C
+		1022 0010  Xilinx Varium C1100
+		1022 100d  Xilinx KCU1500 Extended
+		1022 100f  Xilinx Alveo U55C Extended
+		1022 1010  Xilinx Varium C1100 Extended
+		12ba 0002  XUPVV8 VU13P
+		12ba 0013  XUPVV8 VU9P
+		1a4a 0003  PGP Card GEN3
+		1a4a 0004  PGP Card GEN4
+		1d92 0011  PC821 KU085
+		1d92 0012  PC821 KU115
+		4144 0001  ADM-PCIE-KU3
 	2040  EXO PCIe TEM
 	3000  COB DTM V1
 	3001  COB DTM V2
@@ -25355,7 +25956,10 @@
 	0016  SEL-3350 Serial Expansion Board
 	0017  SEL-3350 GPIO Expansion Board
 	0018  SEL-3390E4 Ethernet Adapter
+	0019  SEL-2241-2/SEL-3361 Mainboard
 	001c  SEL-3390E4 Ethernet Adapter
+	001d  SEL-3350 GPIO Expansion Board
+	001e  SEL-3350 Serial Expansion Board
 1aab  Silver Creations AG
 	7750  Sceye 10L
 1aae  Global Velocity, Inc.
@@ -25431,8 +26035,9 @@
 	0a58  microEnable 5 VD8-CL
 # CameraLink frame grabber
 	0a5a  microEnable 5 AD8-CL
-# CoaXpress frame grabber
+	0a62  imaFlex CXP-12 Quad
 	0a64  imaWorx CXP-12 Quad
+	0a69  imaFlex CXP-12 Penta
 # OEM product
 	0b52  mE5 Abacus 4G Base
 # OEM product
@@ -25580,7 +26185,7 @@
 1b03  Magnum Semiconductor, Inc,
 	6100  DXT/DXTPro Multiformat Broadcast HD/SD Encoder/Decoder/Transcoder
 	7000  D7 Multiformat Broadcast HD/SD Encoder/Decoder/Transcoder
-1b08  MSC Technologies GmbH
+1b08  Tria Technologies GmbH
 1b0a  Pegatron
 	9602  RS780/RS880 PCI to PCI bridge (int gfx)
 1b13  Jaton Corp
@@ -25625,6 +26230,7 @@
 	2423  ASM4242 PCIe Switch Downstream Port
 	2425  ASM4242 USB 4 / Thunderbolt 3 Host Router
 	2426  ASM4242 USB 3.2 xHCI Controller
+	2463  ASM2464PD USB4 Device Controller 40G
 	2806  ASM2806 4-Port PCIe x2 Gen3 Packet Switch
 	2812  ASM2812 6-Port PCIe x4 Gen3 Packet Switch
 	2824  ASM2824 PCIe Gen3 Packet Switch
@@ -25683,7 +26289,11 @@
 	0020  ADQ14
 	0023  ADQ7
 	0026  ADQ8
-	0031  ADQ3
+	0031  ADQ32/ADQ33
+	0032  ADQ System Manager
+	0033  ADQ36
+	0034  ADQ30
+	0035  ADQ35
 	2014  TX320
 	2019  S6000
 # now owned by HGST (a Western Digital subsidiary)
@@ -25704,6 +26314,9 @@
 # device 1b4b:0100 reports incorrect vendor id due to hw erratum (correct is 11ab)
 	0100  88F3700 [Armada 3700 Family] ARM SoC
 	0640  88SE9128 SATA III 6Gb/s RAID Controller
+	1092  88SS1092 NVMe SSD Controller
+	1160  88NV1160 PCIe x2 NVMe SSD Controller (DRAM-less)
+	1321  88SS1321 NVMe SSD Controller
 	2241  88NR2241 Non-Volatile memory controller
 		1028 2112  BOSS-N1 Monolithic
 		1028 2113  BOSS-N1 Modular
@@ -25712,17 +26325,21 @@
 		1028 2286  BOSS-N1 DC-MHS
 		1028 2287  BOSS-N1 Modular DC-MHS
 		1028 23b0  eBOSS-N1 DC-MHS
+		1590 02f6  NS204i-p Gen10+ Boot Controller
 		1b4b 2241  Santa Cruz NVMe Host Adapter
 		1b96 4000  WD_BLACK AN1500 NVMe SSD
 		1d49 0306  ThinkSystem M.2 NVMe 2-Bay RAID Enablement Kit
 		1d49 0307  ThinkSystem 7mm NVMe 2-Bay Rear RAID Enablement Kit
 		207d 0800  TrustRAID B310n
-		207d 0801  TrustRAID B260s
 		4c52 9541  LRNV9541 2-port M.2 NVMe Raid Adapter
 	2b42  88W8997 2.4/5 GHz Dual-Band 2x2 Wi-Fi® 5 (802.11ac) + Bluetooth® 5.3 Solution
 	2b43  NXP 88W9098 Wi-Fi 6 (ax) MAC #1
 	2b44  NXP 88W9098 Wi-Fi 6 (ax) MAC #2
 	2b45  NXP 88W9098 Bluetooth 5.3
+	2b56  NXP IW620 Wi-Fi 6 (ax) + Bluetooth 5.3 Combo
+# some cards use this device ID instead of 9230
+	624e  DAWICONTROL DC-624e RAID
+		dc93 624e  DC-624e RAID
 	9120  88SE9120 SATA 6Gb/s Controller
 	9122  88SE912x SATA 6Gb/s Controller [AHCI mode]
 	9123  88SE9123 PCIe SATA 6.0 Gb/s controller
@@ -25763,6 +26380,7 @@
 		1d49 0304  ThinkSystem M.2 SATA 2-Bay RAID Enablement Kit
 		1d49 0305  ThinkSystem 7mm SATA 2-Bay Rear RAID Enablement Kit
 		4c52 9630  LRST9630 4-port SATA3(6Gb/s) Raid Adapter
+		dc93 624e  DC-624e RAID
 	9235  88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller
 	9445  88SE9445 PCIe 2.0 x4 4-Port SAS/SATA 6 Gbps RAID Controller
 	9480  88SE9480 SAS/SATA 6Gb/s RAID controller
@@ -25776,6 +26394,20 @@
 # 2xHDMI and 2xHD-SDI inputs
 	e5f4  MPEG2 and H264 Encoder-Transcoder
 	f1c4  Dual ASI-RX/TX-CI card
+1b59  Achronix Semiconductor Corporation
+	0010  VectorPath S7t-VG6
+		1b59 ac10  SDK demonstration design
+		1b59 ac12  Ethernet board link
+		1b59 ac13  DDR4 PCIe Ethernet demonstration design
+		1b59 ac15  Licensing reference design
+		1b59 ac16  Partial reconfiguration reference design
+	0012  VectorPath VP815
+		1b59 ac10  SDK demonstration design
+		1b59 ac12  Ethernet board link
+		1b59 ac13  DDR4 PCIe Ethernet demonstration design
+		1b59 ac15  Licensing reference design
+		1b59 ac16  Partial reconfiguration reference design
+	0013  VectorPath VP708
 1b5e  STAR-Dundee Ltd.
 	0001  SpaceWire PCI Mk2
 	0002  SpaceWire PCIe Mk1
@@ -25838,6 +26470,7 @@
 	2720  Ultrastar DC SN650 NVMe SSD
 	2721  Ultrastar DC SN650 NVMe SSD
 	2722  Ultrastar DC SN655 NVMe SSD
+	2750  Ultrastar DC SN861 NVMe SSD
 	2751  Ultrastar DC SN861 NVMe SSD
 	3001  RapidFlex C2000 NVMe Initiator
 	3714  PC SN730 NVMe SSD
@@ -25957,17 +26590,18 @@
 # Nytro 5060H (Rocinante High Performance) non-SED
 		1bb1 0181  Nytro 5060H
 		1bb1 01a1  Nytro XP7102
+	0153  Nytro 5x50 NVMe SSD
 	0155  Nytro 5x50 NVMe SSD
+	2000  PCIe Gen4 SSD
 	5012  FireCuda/IronWolf 510 SSD
 	5013  BarraCuda Q5 NVMe SSD (DRAM-less)
 	5016  FireCuda 520/IronWolf 525 SSD
 	5018  E18 PCIe SSD
 	5019  BarraCuda PCIe SSD (DRAM-less)
-# 2TB
-	5021  FireCuda 520 SSD
+	5021  PCIe Gen4 SSD
 # 1TB
 	5026  FireCuda 540 SSD
-	5027  LaCie Rugged SSD Pro5
+	5027  BarraCuda 530 SSD / LaCie Rugged SSD Pro5
 	5100  PCIe Gen3 SSD
 	5101  PCIe Gen5 SSD
 1bb3  Bluecherry
@@ -25988,16 +26622,30 @@
 	1001  PCIe 3TG6-P Controller
 	1002  PCIe 3TE6 Controller (DRAM-less)
 	1160  PCIe 3TE2 Controller
+	1202  PCIe 3TE8 Controller
+	120a  PCIe 3IE8 Controller
+	120b  PCIe 3TO8 Controller
 	1321  PCIe 4TG-P Controller
 	1322  PCIe 4TE Controller
+	1602  PCIe 4TE3 Controller
+	160a  PCIe 4IE3 Controller
 	2262  PCIe 3TG3-P Controller
 	5208  PCIe 3TE7 Controller
-	5216  PCIe 3TE8 Controller
+	5216  PCIe 3TE9 controller
+	521a  PCIe 3IE9 Controller
+	5220  PCIe 4TE2 Controller
+	522a  PCIe 4IE2 Controller
 	5236  PCIe 4TG2-P Controller
+# based on PCIe 4TG2-P Controller, for 4TS2-P series
+	523a  PCIe 4TS2-P Controller
+	523b  PCIe 4IG2-P Controller
+# based on SM8366 Controller
+	8366  PCIe 5TS-P Controller
 1bcd  Apacer Technology
 	0120  NVMe SSD Drive 960GB
-	0180  PB4480 NVMe PCIe SSD (DRAM-less)
+	0180  PB4480 NVMe SSD (DRAM-less)
 	0310  NVMe SSD Drive 480GB
+	5027  AS2280Q4 NVMe SSD
 1bcf  NEC Corporation
 	001c  Vector Engine 1.0
 1bd0  Astronics Corporation
@@ -26060,7 +26708,7 @@
 	1000  G7200 series U.2 NVMe SSD
 1bfc  Duagon AG
 1bfd  EeeTOP
-1c00  Nanjing Qinheng Microelectronics Co., Ltd.
+1c00  WCH (Nanjing Qinheng Microelectronics Co., Ltd.)
 	2170  CH351 PCIe Parallel Port Adapter
 	2273  CH351 PCIe Dual Port Serial Adapter
 	3050  CH382L PCIe Parallel Port Adapter
@@ -26068,6 +26716,8 @@
 	3252  CH382 PCIe Dual Port Serial Adapter
 # Device ID reused: CH352 is for PCI bus, CH382 for PCIe.
 	3253  CH352/CH382 PCI/PCIe Dual Port Serial Adapter
+	3470  CH384 Serial Adapter, 4-port mode
+	3853  CH384 Serial Adapter, 8-port mode
 1c09  CSP, Inc.
 	4254  10G-PCIE3-8D-2S
 	4255  10G-PCIE3-8D-Q
@@ -26081,6 +26731,10 @@
 	4265  10G-PCIE3-8E-2S Network Adapter
 	5000  25G-PCIE3-8A-2S Security Intelligent Adapter
 	5001  25G-PCIE3-8B-2S Security Intelligent Adapter
+1c19  LaCie
+	0003  6big and 12big Thunderbolt 3
+		1c19 0003  6big Thunderbolt 3
+		1c19 0004  12big Thunderbolt 3
 1c1c  Symphony
 	0001  82C101
 1c1f  SoftLab-NSK
@@ -26142,6 +26796,7 @@
 	a015  FB2CGHH Capture 2x100Gb [Tivoli]
 	a016  FB2CG Capture 8x25Gb [Savona]
 	a017  FB2CGHH Capture 8x25Gb [Tivoli] a017
+	a01b  FB2CDG1 Capture 2x100Gb [Thunderfjord]
 # Used on V120 VME Crate Controller
 1c32  Highland Technology, Inc.
 1c33  Daktronics, Inc
@@ -26155,6 +26810,8 @@
 1c44  Enmotus Inc
 	1100  Fuzedrive NVMe SSD
 	8000  8000 Storage IO Controller
+1c4e  TECHWAY
+	7024  Default PCIe Endpoint ID
 # A Western Digital Subsidiary
 1c58  HGST, Inc.
 	0003  Ultrastar SN100 Series NVMe SSD
@@ -26304,8 +26961,20 @@
 		1c5f 1421  NVMe SSD PBlaze7 7A40 1920G 2.5" U.2
 		1c5f 1431  NVMe SSD PBlaze7 7A40 3840G 2.5" U.2
 		1c5f 1441  NVMe SSD PBlaze7 7A40 7680G 2.5" U.2
+		1c5f 1631  NVMe SSD PBlaze7 7A40 3840G 2.5" U.2
+		1c5f 1641  NVMe SSD PBlaze7 7A40 7680G 2.5" U.2
+		1c5f 1651  NVMe SSD PBlaze7 7A40 15360G 2.5" U.2
+		1c5f 1661  NVMe SSD PBlaze7 7A40 30720G 2.5" U.2
+		1c5f 1751  NVMe SSD PBlaze7 7A40 Ocean 15360G 2.5" U.2
+		1c5f 1761  NVMe SSD PBlaze7 7A40 Ocean 30720G 2.5" U.2
+		1c5f 1771  NVMe SSD PBlaze7 7A40 Ocean 61440G 2.5" U.2
+		1c5f 1781  NVMe SSD PBlaze7 7A40 Ocean 122880G 2.5" U.2
 		1c5f 5431  NVMe SSD PBlaze7 7A46 3200G 2.5" U.2
 		1c5f 5441  NVMe SSD PBlaze7 7A46 6400G 2.5" U.2
+		1c5f 5631  NVMe SSD PBlaze7 7A46 3200G 2.5" U.2
+		1c5f 5641  NVMe SSD PBlaze7 7A46 6400G 2.5" U.2
+		1c5f 5651  NVMe SSD PBlaze7 7A46 12800G 2.5" U.2
+		1c5f 5661  NVMe SSD PBlaze7 7A46 25600G 2.5" U.2
 	003d  PBlaze5 920/926
 		1c5f 0a30  NVMe SSD PBlaze5 920 3840G AIC
 		1c5f 0a31  NVMe SSD PBlaze5 920 3840G 2.5" U.2
@@ -26373,6 +27042,13 @@
 	0557  PBlaze5 910/916
 1c63  Science and Research Centre of Computer Technology (JSC "NICEVT")
 	0008  K1927BB1Ya [EC8430] Angara Interconnection Network Adapter
+1c67  PreSonus Audio Electronics Inc.
+	0101  Quantum
+	0102  Quantum 2
+	0103  Quantum 4848
+	0104  Quantum 2626
+# Unreleased product
+	0105  Quantum Mobile
 # Other World Computing
 1c7a  OWC
 1c7e  TTTech Computertechnik AG
@@ -26418,12 +27094,16 @@
 	1602  LEGEND 900 NVMe SSD (DRAM-less)
 # SX6000LNP
 	2263  XPG SX6000 Lite NVMe SSD (DRAM-less)
+	2708  Premier Extreme SDXC SD 7.0 / microSDXC SD 7.1 Express Card (DRAM-less)
 	32a8  SM2P32A8 NVMe SSD (DRAM-less)
 	33f3  IM2P33F3 NVMe SSD (DRAM-less)
 	33f4  IM2P33F4 NVMe SSD (DRAM-less)
 	33f8  IM2P33F8 series NVMe SSD (DRAM-less)
+	413d  SM2P41D3Q NVMe SSD (DRAM-less)
+	41b8  IM2P41B8P NVMe SSD
 	41c3  SM2P41C3 NVMe SSD (DRAM-less)
 	41c8  SM2P41C8 NVMe SSD (DRAM-less)
+	41d3  SM2P41D3 NVMe SSD (DRAM-less)
 	5236  XPG GAMMIX S70 BLADE NVMe SSD
 	5350  XPG GAMMIX S50, S50 Lite NVMe SSD
 # PREMIUM NVMe SSD for PlayStation 5
@@ -26447,8 +27127,15 @@
 	633a  LEGEND 900 NVMe SSD (DRAM-less)
 	634c  LEGEND 820 NVMe SSD (DRAM-less)
 	635a  XPG GAMMIX S60 NVMe SSD (DRAM-less)
+	636a  XPG GAMMIX S55 NVMe SSD (DRAM-less)
+	641a  LEGEND 970 PRO NVMe SSD
 	642a  XPG GAMMIX S50 CORE NVMe SSD (DRAM-less)
+	646a  XPG MARS 980 BLADE NVMe SSD
+	648a  LEGEND 860 NVMe SSD (DRAM-less)
+	64ba  LEGEND 900 PRO NVMe SSD
 	8201  XPG SX8200 Pro PCIe Gen3x4 M.2 2280 Solid State Drive
+	a010  TRUSTA T7P5 NVMe SSD
+	a120  TRUSTA T5P4B NVMe SSD
 1cc4  Shenzhen Unionmemory Information System Ltd.
 	1203  NVMe SSD Controller UHXXXa series
 		1cc4 a121  NVMe SSD UHXXXa series U.2 960GB
@@ -26469,7 +27156,15 @@
 	2263  AM611 PCIe 3.0 x2 NVMe SSD 256GB
 	5008  AM610 PCIe 3.0 x2 NVMe SSD 128GB, 256GB
 	5012  AH530 PCIe 3.0 NVMe SSD 512GB
+	5201  AM520 PCIe 3.0 NVMe SSD 128GB
 	5212  AM521 PCIe 3.0 NVMe SSD 256GB
+	5414  AM541 PCIe 4.0 NVMe SSD 1024GB
+	6020  NVMe SSD Controller UM3X1X series
+		1cc4 8320  NVMe SSD UM301a M.2 480GB
+		1cc4 8321  NVMe SSD UM301a M.2 960GB
+		1cc4 8322  NVMe SSD UM301a M.2 1.92TB
+		1ea0 8320  NVMe SSD TM1300 M.2 480GB
+		1ea0 8322  NVMe SSD TM1300 M.2 1.92TB
 	6201  AM620 PCIe 3.0 NVMe SSD 128GB
 	6202  AM620 PCIe 3.0 NVMe SSD 256GB
 	6203  AM620 PCIe 3.0 NVMe SSD 512GB
@@ -26479,6 +27174,7 @@
 	6304  AM630 PCIe 4.0 NVMe SSD 1024GB
 	634c  LEGEND 820 NVMe SSD (DRAM-less)
 	635a  GAMMIX S60 NVMe SSD (DRAM-less)
+	660b  AH660 PCIe 4.0 NVMe SSD 512GB
 	660c  AH660 PCIe 4.0 NVMe SSD
 	6a01  AM620 PCIe 3.0 NVMe SSD 128GB
 	6a02  AM6A0 PCIe 4.0 NVMe SSD 256GB
@@ -26486,9 +27182,22 @@
 	6a04  AM6A0 PCIe 4.0 NVMe SSD 1024GB (DRAM-less)
 	6a13  RPJYJ512MKN1QWQ PCIe 4.0 NVMe SSD 512GB (DRAM-less)
 	6a14  AM6A1 PCIe 4.0 NVMe SSD 1024GB (DRAM-less)
+	6b02  AM6B0 PCIe 4.0 NVMe SSD 256GB (DRAM-less)
+	6b03  RPETJ512MMW1MDQ PCIe 4.0 NVMe SSD 512GB (DRAM-less)
 	6b04  AM6B0 PCIe 4.0 NVMe SSD
 	6b13  AM6B1 PCIe 4.0 NVMe SSD 512GB (DRAM-less)
 	6b14  RPJYJ1T24MLR1HWY PCIe 4.0 NVMe SSD 1024GB (DRAM-less)
+	6c13  AM6C1 PCIe 4.0 NVMe SSD
+	6d03  AM6DX PCIe 5.0 NVMe SSD
+	7030  NVMe SSD Controller UH7X3X series
+		1cc4 7112  NVMe SSD UH733a U.2 1.6TB
+		1cc4 7113  NVMe SSD UH733a U.2 3.2TB
+		1cc4 7114  NVMe SSD UH733a U.2 6.4TB
+		1cc4 7115  NVMe SSD UH733a U.2 12.8TB
+		1cc4 7122  NVMe SSD UH713a U.2 1.92TB
+		1cc4 7123  NVMe SSD UH713a U.2 3.84TB
+		1cc4 7124  NVMe SSD UH713a U.2 7.68TB
+		1cc4 7125  NVMe SSD UH713a U.2 15.36TB
 	8030  NVMe SSD Controller UH8X2X/UH7X2X series
 		1cc4 1122  NVMe SSD UH812a U.2 1.92TB
 		1cc4 1123  NVMe SSD UH812a U.2 3.84TB
@@ -26510,10 +27219,34 @@
 		1cc4 3123  NVMe SSD UH712a U.2 3.84TB
 		1cc4 3124  NVMe SSD UH712a U.2 7.68TB
 		1cc4 3125  NVMe SSD UH712a U.2 15.36TB
+		1cc4 5125  NVMe SSD UH802a U.2 15.36TB
+		1cc4 5126  NVMe SSD UH802a U.2 30.72TB
+		1cc4 5127  NVMe SSD UH802a U.2 61.44TB
+		1cc4 6112  NVMe SSD UH832c U.2 1.6TB
+		1cc4 6113  NVMe SSD UH832c U.2 3.2TB
+		1cc4 6114  NVMe SSD UH832c U.2 6.4TB
+		1cc4 6115  NVMe SSD UH832c U.2 12.8TB
+		1cc4 6122  NVMe SSD UH812c U.2 1.92TB
+		1cc4 6123  NVMe SSD UH812c U.2 3.84TB
+		1cc4 6124  NVMe SSD UH812c U.2 7.68TB
+		1cc4 6125  NVMe SSD UH812c U.2 15.36TB
+		1cc4 6214  NVMe SSD UH832c E3.S 6.4TB
+		1cc4 6215  NVMe SSD UH832c E3.S 12.8TB
+		1cc4 6224  NVMe SSD UH812c E3.S 7.68TB
+		1cc4 6225  NVMe SSD UH812c E3.S 15.36TB
 		1ea0 4124  NVMe SSD TP3511 U.2 7.68TB
 		1ea0 4125  NVMe SSD TP3511 U.2 15.36TB
 		1ea0 4224  NVMe SSD TP3511 E3.S 7.68TB
 		1ea0 4225  NVMe SSD TP3511 E3.S 15.36TB
+		1ea0 5125  NVMe SSD TP3310 U.2 15.36TB
+		1ea0 5126  NVMe SSD TP3310 U.2 30.72TB
+		1ea0 5127  NVMe SSD TP3310 U.2 61.44TB
+		1ea0 6124  NVMe SSD TP3510 U.2 7.68TB
+		1ea0 6125  NVMe SSD TP3510 U.2 15.36TB
+		1ea0 6224  NVMe SSD TP3510 E3.S 7.68TB
+		1ea0 6225  NVMe SSD TP3510 E3.S 15.36TB
+		1ea0 7124  NVMe SSD TP3512 U.2 7.68TB
+		1ea0 7125  NVMe SSD TP3512 U.2 15.36TB
 1cc5  Embedded Intelligence, Inc.
 	0100  PCIe-CAN-02 Dual CAN bus (9-pin male). PCI Express x1.
 	0101  PCIe-CAN-01 Single CAN bus (9-pin male). PCI Express x1.
@@ -26570,16 +27303,16 @@
 	8046  NX I512 OVS PF Ethernet Controller
 	8047  NEO X510 BOND PF Ethernet Controller
 	8048  NEO X510 OVS PF Ethernet Controller
-	8049  NX E312 SRIOV RDMA PF Ethernet Controller
+	8049  NX E312-02R00 Ethernet Controller [RDMA]
 	804a  NEO X512 NOF PF Ethernet Controller
 	804b  NEO X512 SRIOV PF Ethernet Controller
 	804c  NEO X512 INITIATOR1 PF Ethernet Controller
 	804d  NEO X512 INITIATOR2 PF Ethernet Controller
 	804e  NX I512 UPF PF Ethernet Controller
 	804f  NX I512 UPF VF Ethernet Controller Virtual Function
-	8060  NX E312 SRIOV RDMA VF Ethernet Controller Virtual Function
-	8061  NX E310 SRIOV PF Ethernet Controller
-	8062  NX E310 SRIOV VF Ethernet Controller Virtual Function
+	8060  NX E312-02R00 Ethernet Controller Virtual Function [RDMA]
+	8061  NX E310-01N00 Ethernet Controller
+	8062  NX E310-01N00 Ethernet Controller Virtual Function
 	8063  NX I510 BOND PF Ethernet Controller
 	8064  NX I510 OVS PF Ethernet Controller
 	8065  NX I510 VDPA VF Ethernet Controller Virtual Function
@@ -26591,30 +27324,34 @@
 	806d  NX I512 RDMA PF Ethernet Controller
 	806e  NX I512 RDMA VF Ethernet Controller Virtual Function
 	806f  NX I512 UPF BOND PF Ethernet Controller
-	807d  NX E312S SRIOV PF Ethernet Controller
-	807e  NX E316 SRIOV PF Ethernet Controller
-	807f  NX E316 SRIOV VF Ethernet Controller Virtual Function
-	8080  NX E311 SRIOV PF Ethernet Controller
-	8081  NX E311 SRIOV VF Ethernet Controller Virtual Function
+	807d  NX E312S-01R00 Ethernet Controller
+	807e  NX E316-01R00 Ethernet Controller
+	807f  NX E316-01R00 Ethernet Controller Virtual Function
+	8080  NX E311-01N00 Ethernet Controller
+	8081  NX E311-01N00 Ethernet Controller Virtual Function
 	8082  NX I511 SRIOV PF Ethernet Controller
 	8083  NX I511 SRIOV VF Ethernet Controller Virtual Function
-	8084  NX E310 RDMA PF Ethernet Controller
-	8085  NX E310 RDMA VF Ethernet Controller Virtual Function
+	8084  NX E310-02R00 Ethernet Controller [RDMA]
+	8085  NX E310-02R00 Ethernet Controller Virtual Function [RDMA]
 	8086  NX I510 SRIOV SEC PF Ethernet Controller
 	8087  NX I510 SRIOV SEC VF Ethernet Controller Virtual Function
-	8088  NX E312S SRIOV VF Ethernet Controller Virtual Function
+	8088  NX E312S-01R00 Ethernet Controller Virtual Function
 	8089  NEO X512 SRIOV PF Ethernet Controller
 	808a  NEO X512 SRIOV PF Ethernet Controller
-	80a0  NX E312 PF Ethernet Controller
-	80a1  NX E312 VF Ethernet Controller Virtual Function
-	80a2  NX E312S_D SRIOV PF Ethernet Controller
-	80a3  NX E312S_D SRIOV VF Ethernet Controller Virtual Function
+	80a0  NX E312-01N00 Ethernet Controller
+	80a1  NX E312-01N00 Ethernet Controller Virtual Function
+	80a2  NX E312SD-01R00 Ethernet Controller
+	80a3  NX E312SD-01R00 Ethernet Controller Virtual Function
 	80a4  NX I512 OFFLOAD PF Ethernet Controller
+	80ab  NX E318-01R00 Ethernet Controller
+	80ac  NX E318-01R00 Ethernet Controller Virtual Function
+	80b6  NX E310S-01N00 Ethernet Controller
+	80b7  NX E310S-01N00 Ethernet Controller Virtual Function
 1cf7  Subspace Dynamics
 1cfa  Corsair Memory, Inc
 1cfd  Mangstor
 	6300  MX6300 series PCIe x8 NVMe SSD
-1d00  Pure Storage
+1d00  Everpure, Inc.
 1d05  AIstone Global Limited
 	6027  B760-N2D5 motherboard
 	7001  H610-N2 motherboard
@@ -26624,6 +27361,8 @@
 		1d0f 0000  Trainium
 	7264  NeuronDevice (Inferentia2)
 	7364  NeuronDevice (Trainium2)
+	7564  NeuronDevice (Trainium3)
+	7565  NeuronDevice (Trainium3)
 	8061  NVMe EBS Controller
 	cd01  NVMe SSD Controller
 	ec20  Elastic Network Adapter (ENA)
@@ -26631,6 +27370,7 @@
 	efa1  Elastic Fabric Adapter (EFA)
 	efa2  Elastic Fabric Adapter (EFA)
 	efa3  Elastic Fabric Adapter (EFA)
+	efa4  Elastic Fabric Adapter (EFA)
 1d17  Zhaoxin
 	070f  ZX-100 PCI Express Root Port
 	0710  ZX-100/ZX-200 PCI Express Root Port
@@ -26640,14 +27380,14 @@
 	0714  ZX-100/ZX-200 PCI Express Root Port
 	0715  ZX-100/ZX-200 PCI Express Root Port
 	0716  ZX-D PCI Express Root Port
-	0717  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
-	0718  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
-	0719  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
+	0717  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
+	0718  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
+	0719  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
 	071a  KX-5000/KX-6000/KX-6000G/KH-40000 PCI Express Root Port
-	071b  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
-	071c  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
-	071d  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
-	071e  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
+	071b  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
+	071c  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
+	071d  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
+	071e  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
 	071f  ZX-200 Upstream Port of PCI Express Switch
 	0720  ZX-200 PCIE RC6 controller
 	0721  ZX-200 Downstream Port of PCI Express Switch
@@ -26663,26 +27403,58 @@
 	0739  KX-7000 PCIE Express Root Port
 	073a  KX-7000 PCIE Express Root Port
 	073b  KX-7000 PCIE Express Root Port
+	073c  KH-50000 PCI Express Root Port
+	073d  KH-50000 PCI Express Root Port
+	073e  KH-50000 PCI Express Root Port
+	073f  KH-50000 PCI Express Root Port
+	0740  KH-50000 PCI Express Root Port
+	0741  KH-50000 PCI Express Root Port
+	0742  KH-50000 PCI Express Root Port
+	0743  KH-50000 PCI Express Root Port
+	0744  KH-50000 PCI Express Root Port
+	0745  KH-50000 PCI Express Root Port
+	0746  KH-50000 PCI Express Root Port
+	0747  KH-50000 PCI Express Root Port
+	0748  KH-50000 PCI Express Root Port
+	0749  KH-50000 PCI Express Root Port
+	074a  KH-50000 PCI Express Root Port
+	074b  KH-50000 PCI Express Root Port
+	074c  KH-50000 PCI Express Root Port
+	074d  KH-50000 PCI Express Root Port
+	074e  KH-50000 PCI Express Root Port
+	074f  KH-50000 PCI Express Root Port
+	0750  KH-50000 PCI Express Root Port
+	0751  KH-50000 PCI Express Root Port
+	0752  KH-50000 PCI Express Root Port
+	0757  KH-50000 PCI Express Root Port
+	0758  KH-50000 PCI Express Root Port
+	0759  KH-50000 PCI Express Root Port
+	075a  KH-50000 PCI Express Root Port
+	075b  KH-50000 PCI Express Root Port
+	075c  KH-50000 PCI Express Root Port
+	075d  KH-50000 PCI Express Root Port
+	075e  KH-50000 PCI Express Root Port
 	1000  ZX-D Standard Host Bridge
-	1001  ZX-D/ZX-E/KH-40000/KX-7000 Miscellaneous Bus
+	1001  ZX-D/ZX-E/KH-40000/KX-7000/KH-50000 Miscellaneous Bus
 	1003  ZX-E Standard Host Bridge
 	1005  KH-40000 Standard Host Bridge
 	1006  KX-6000G Standard Host Bridge
 	1007  KX-7000 Standard Host Bridge
+	1008  KH-50000 Standard Host Bridge
 	3001  ZX-100 Standard Host Bridge
 	300a  ZX-100 Miscellaneous Bus
-	3038  ZX-100/ZX-200/KX-6000/KX-6000G/KH-40000/KX-7000 Standard Universal PCI to USB Host Controller
-	3104  ZX-100/ZX-200/KX-6000/KX-6000G/KH-40000/KX-7000 Standard Enhanced PCI to USB Host Controller
-	31b0  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 Standard Host Bridge
-	31b1  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 Standard Host Bridge
+	3038  ZX-100/ZX-200/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Standard Universal PCI to USB Host Controller
+	3104  ZX-100/ZX-200/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Standard Enhanced PCI to USB Host Controller
+	31b0  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Standard Host Bridge
+	31b1  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Standard Host Bridge
 	31b2  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 DRAM Controller
-	31b3  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 Power Management Controller
-	31b4  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 I/O APIC
-	31b5  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 Scratch Device
-	31b7  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 Standard Host Bridge
+	31b3  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Power Management Controller
+	31b4  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 I/O APIC
+	31b5  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Scratch Device
+	31b7  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Standard Host Bridge
 	31b8  ZX-100/ZX-D PCI to PCI Bridge
 	3200  KX-7000 Host Bridge
-	3288  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 High Definition Audio Controller
+	3288  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 High Definition Audio Controller
 	345b  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000 Miscellaneous Bus
 	3a02  ZX-100 C-320 GPU
 	3a03  ZX-D C-860 GPU
@@ -26695,12 +27467,12 @@
 	3c00  KH-40000/KX-7000 DRAM Controller
 	3c02  KX-6000G DRAM Controller
 	3d01  KX-6000G C-1080 GPU
-	9002  ZX-100/ZX-200/KH-40000/KX-7000 EIDE Controller
+	9002  ZX-100/ZX-200/KH-40000/KX-7000/KH-50000 EIDE Controller
 	9003  ZX-100/KX-6000/KX-6000G EIDE Controller
-	9043  KX-6000G/KH-40000/KX-7000 RAID Controller
+	9043  KX-6000G/KH-40000/KX-7000/KH-50000 RAID Controller
 	9045  ZX-100/ZX-D/ZX-E RAID Accelerator 0
 	9046  ZX-D/ZX-E RAID Accelerator 1
-	9083  ZX-100/ZX-200/KX-6000/KX-6000G/KH-40000/KX-7000 StorX AHCI Controller
+	9083  ZX-100/ZX-200/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 StorX AHCI Controller
 	9084  ZX-100 StorX AHCI Controller
 	9100  ZX-200 Cross bus
 	9101  ZX-200 Traffic Controller
@@ -26717,12 +27489,13 @@
 	9204  KX-6000/KX-6000G/KX-7000 USB3 xHCI Host Controller
 	9205  KH-40000 USB eXtensible Host Controller
 	9206  KX-7000 USB4 Contoller
+	9207  KH-50000 USB eXtensible Host Controller
 	9286  ZX-D eMMC Host Controller
-	9300  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 eSPI Host Controller
+	9300  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 eSPI Host Controller
 	9500  KX-7000 I2S Controller
 	9501  KX-7000 I2S Controller
 	95d0  ZX-100 Universal SD Host Controller
-	f410  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Com Port
+	f410  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Com Port
 1d18  RME
 	0001  Fireface UFX+
 # acquired by Intel
@@ -26753,6 +27526,8 @@
 	0014  PM4
 	0015  PM4edge
 	0016  PM4edge User Device
+1d39  Baikal Electronics
+	8060  Baikal-M PCIe Controller
 1d40  Techman Electronics (Changshu) Co., Ltd.
 	5501  XC100C55-xxxx NVME SSD
 	5c01  XC100C5C-xxxx, XC100E5C-xxxx NVME SSD
@@ -26764,6 +27539,8 @@
 1d5c  Fantasia Trading LLC
 1d61  Technobox, Inc.
 1d62  Nebbiolo Technologies
+1d63  StorArt Technology Co., Ltd
+	3801  SA3801 PCIe 3.0 x2 NVMe controller
 1d65  Imagine Communications Corp.
 	04de  Taurus/McKinley
 # nee Celeno Communications
@@ -26794,6 +27571,7 @@
 	14c0  AQC113C NBase-T/IEEE 802.3an Ethernet Controller [Marvell Scalable mGig]
 	80b1  AQtion AQC100S NBase-T/IEEE 802.3an Ethernet Controller [Atlantic 10G]
 	87b1  AQtion AQC107S NBase-T/IEEE 802.3an Ethernet Controller [Atlantic 10G]
+		16b8 72e1  Solo 10G Thunderbolt 3 PCIe 10Gb Ethernet Adapter
 		1c7a de2b  Thunderbolt 10G Ethernet Adapter
 	93c0  AQtion AQC114CS NBase-T/IEEE 802.3bz Ethernet Controller [Antigua 5G]
 	94c0  AQtion AQC113CS NBase-T/IEEE 802.3an Ethernet Controller [Antigua 10G]
@@ -26849,6 +27627,10 @@
 	102a  AR-TK242-FX2 [4x100GbE Gen5 Packet Capture-Replay Device]
 	102b  AR-ARKV-FX1 [Arkville 128B DPDK Data Mover for Versal/CPM5]
 	102c  AR-TK242-V80 [Gen5 PCAP Processor]
+	102d  AR-TK242-FX2 [8x10GbE Gen5 Packet Capture-Replay Device]
+	102e  AR-TK242-FX2 [8x25GbE Gen5 Packet Capture-Replay Device]
+	102f  AR-TK242-FX2 [1x400GbE Gen5 Packet Capture-Replay Device]
+	1030  AR-ARKSTREAM [Arkville Streaming DMA]
 	4200  A5PL-E1-10GETI [10 GbE Ethernet Traffic Instrument]
 1d72  Xiaomi
 1d78  DERA Storage
@@ -26927,6 +27709,7 @@
 	2263  NVMe PCIe SSD 110S/112S/120S/MTE300S/MTE400S/MTE652T2 (DRAM-less)
 	2264  NVMe PCIe SSD 250H
 	2267  NVMe PCIe SSD 220S/240S/MTE710T
+	2268  NVMe PCIe SSD 245S (DRAM-less)
 	2269  NVMe PCIe SSD 410S (DRAM-less)
 	5766  NVMe PCIe SSD 110Q (DRAM-less)
 1d7c  Aerotech, Inc.
@@ -26942,12 +27725,15 @@
 1d87  Rockchip Electronics Co., Ltd
 	0100  RK3399 PCI Express Root Port
 	1808  RK1808 Neural Network Processor Card
+	182a  RK182x Edge AI Computing Coprocessor
 	3528  RK3528 PCI Express Root Port
 	3562  RK3562 PCI Express Root Port
 	3566  RK3568 Remote Signal Processor
+	3576  RK3576
 	3588  RK3588
 1d89  YEESTOR Microelectronics Co., Ltd
 	0280  PCIe NVMe SSD
+	ef25  GDRAMARS GMT1000 NVMe SSD (DRAM-less)
 1d8f  Exegy
 1d92  Abaco Systems Inc.
 1d93  YADRO
@@ -26976,6 +27762,10 @@
 	1466  Data Fabric: Device 18h; Function 6
 	1467  Data Fabric: Device 18h; Function 7
 	1468  NTBCCP
+	14ab  HGE1000 1000/100/10 Mb Ethernet Controller
+	200b  HGE2500 2500/1000/100/10 Mb Ethernet Controller
+	200c  HGE2500 1000/100/10 Mb Ethernet Controller
+	6211  K100_AI
 	7901  FCH SATA Controller [AHCI mode]
 	7904  FCH SATA Controller [AHCI mode]
 	7906  FCH SD Flash Controller
@@ -26985,14 +27775,18 @@
 	0001  Colossus GC2 [C2]
 	0002  Colossus GC1 [S1]
 1d97  Shenzhen Longsys Electronics Co., Ltd.
+	0304  HIKSEMI FUTURE Lite NVMe SSD
 	1062  Lexar NM710 NVME SSD
 	1160  FORESEE P900 BGA NVMe SSD (DRAM-less)
 	1202  Lexar NM610 PRO NVME SSD (DRAM-less)
 	12e4  ORCA 4836 Series eSSD
-	1602  Lexar NM790 NVME SSD (DRAM-less)
+	1602  Lexar NM790 / Patriot Viper VP4300 Lite NVMe SSD (DRAM-less)
+	1806  Lexar NM990 NVMe SSD (DRAM-less)
 	1d97  Lexar NM620 NVME SSD (DRAM-less)
 	2263  SM2263EN/SM2263XT-based OEM NVME SSD (DRAM-less)
 	2269  FORESEE XP2000, Lexar NM760 NVME SSD (DRAM-less)
+	2508  Lexar NM1090 PRO NVMe SSD
+	2708  Lexar microSD Express card (DRAM-less)
 	5216  FORESEE XP1000 / Lexar Professional CFexpress Type B Gold series, NM620 PCIe NVME SSD (DRAM-less)
 	5220  FORESEE XP2100 NVMe SSD (DRAM-less)
 	5236  Lexar NM800 PRO NVME SSD
@@ -27026,7 +27820,8 @@
 	3803  Network Flow Processor 3800 Virtual Function
 1dad  Fungible
 	0108  FC50, FC100, FC200 DPU NVMeoF Adapters
-1db2  ATP ELECTRONICS INC
+1db2  ATP Electronics, Inc.
+1db3  Unisoc (Shanghai) Technologies Co., Ltd.
 1db7  Phytium Technology Co., Ltd.
 	dc20  [X100 Series]
 	dc21  VPU Controller [X100 Series]
@@ -27054,6 +27849,7 @@
 	dc3e  DCController [E2000 Series]
 	dc3f  SATA Controller [D3000M Series]
 1dbb  NGD Systems, Inc.
+	1021  ICS-8100 NVMe SSD
 1dbe  INNOGRIT Corporation
 	5208  NVMe SSD Controller IG5208 [Shasta] (DRAM-less)
 	5216  NVMe SSD Controller IG5216 [Shasta+] (DRAM-less)
@@ -27116,6 +27912,7 @@
 1dc2  Alco Digital Devices Limited
 1dc5  FADU Inc.
 	4081  FC4121 PCIe 4.0 NVMe controller [DELTA]
+	5161  FC5161 PCIe 5.0 NVMe controller [ECHO]
 	6150  FC3081 PCIe 3.0 NVMe controller [BRAVO]
 1dcd  Liqid Inc.
 1dcf  Beijing Sinead Technology Co., Ltd.
@@ -27390,6 +28187,9 @@
 1de5  Eideticom, Inc
 	1000  IO Memory Controller
 	2000  NoLoad Hardware Development Kit
+	2100  NoLoad Accelerator Platform
+	2200  NoLoad Cryptographic Accelerator
+	2300  NoLoad Data Services
 	3000  eBPF-based PCIe Accelerator
 1ded  Alibaba (China) Co., Ltd.
 	107f  Elastic RDMA Adapter
@@ -27424,6 +28224,7 @@
 		1dee 0013  NVMe SSD SP506 7.68T 2.5" U.2
 		1dee 0014  NVMe SSD SP506 15.36T 2.5" U.2
 	5216  KingSpec NX series NVMe SSD (DRAM-less)
+	5236  Acer Predator GM7000 NVMe SSD
 	7700  BIWIN NVMe SSD SP50Y/SP51Y
 1def  Ampere Computing, LLC
 	e005  eMAG PCI Express Root Port 0
@@ -27509,6 +28310,9 @@
 1df8  V&G Information System Co.,Ltd
 	3000  PC NVMe SSD
 		1df8 3100  M.2 NVMe Gen3*4 SSD
+	4000  M.2 NVMe SSD
+		1df8 4001  M.2 NVMe Gen4*4 SSD
+		1df8 4002  M.2 NVMe Gen4*4 SSD
 	c000  DC NVMe SSD
 		1df8 c600  Enterprise U.2 NVMe SSD
 	d000  PC NVMe SSD
@@ -27516,8 +28320,11 @@
 		1df8 d201  M.2 NVMe SSD
 		1df8 d600  M.2 NVMe SSD
 1dfa  Astera Labs, Inc.
+	01e2  CXL 2.0 Memory Controller CM5xxxx [Leo]
+	05c0  PCIe 6 Fabric Switch PF6xxx [Scorpio]
 1dfc  JSC NT-COM
 	1181  TDM 8 Port E1/T1/J1 Adapter
+1e0b  Shenzhen Decenta Technology Co.,LTD
 1e0d  SambaNova Systems, Inc
 1e0f  KIOXIA Corporation
 	0001  NVMe SSD Controller BG4 (DRAM-less)
@@ -27563,7 +28370,7 @@
 		1028 2193  NVMe CD7 E3.S 1.92TB
 		1028 2194  NVMe CD7 E3.S 3.84TB
 		1028 2195  NVMe CD7 E3.S 7.68TB
-	0013  VMe SSD Controller CM7
+	0013  NVMe SSD Controller CM7
 		1028 222d  Ent NVMe CM7 FIPS U.2 RI 30.72TB
 		1028 222e  Ent NVMe CM7 FIPS U.2 RI 15.36TB
 		1028 222f  Ent NVMe CM7 FIPS U.2 RI 7.68TB
@@ -27602,6 +28409,7 @@
 	0018  Exceria Pro NVMe SSD
 	001a  NVMe SSD Controller BG6 (DRAM-less)
 	001b  NVMe SSD Controller EG6 (DRAM-less)
+	001e  NVMe SSD Controller LD2-L
 	001f  NVMe SSD Controller CD8
 		1028 2223  DC NVMe CD8 U.2 SED 15.36TB
 		1028 2224  DC NVMe CD8 U.2 SED 7.68TB
@@ -27649,6 +28457,94 @@
 	0031  PCIe 5.0 NVMe SSD Controller XG10
 	0032  PCIe 4.0 NVMe SSD Controller XG10d
 	0033  Exceria Plus G4 NVMe SSD (DRAM-less)
+	0034  CM9-based E3.S NVMe SSD
+		1028 240f  KCM9FRJE1T92
+		1028 2410  KCM9FRJE3T84
+		1028 2411  KCM9FRJE7T68
+		1028 2412  KCM9FRJE15T3
+		1028 2413  KCM9FRJE30T7
+		1028 2414  KCM9XRJE1T92
+		1028 2415  KCM9XRJE3T84
+		1028 2416  KCM9XRJE7T68
+		1028 2417  KCM9XRJE15T3
+		1028 2418  KCM9XRJE30T7
+		1028 2419  KCM9FVJE1T60
+		1028 241a  KCM9FVJE3T20
+		1028 241b  KCM9FVJE6T40
+		1028 241c  KCM9FVJE12T8
+		1028 241d  KCM9XVJE1T60
+		1028 241e  KCM9XVJE3T20
+		1028 241f  KCM9XVJE6T40
+		1028 2420  KCM9XVJE12T8
+	0035  CM9-based U3 NVMe SSD
+		1028 23fb  KCM9FRUL1T92
+		1028 23fc  KCM9FRUL3T84
+		1028 23fd  KCM9FRUL7T68
+		1028 23fe  KCM9FRUL15T3
+		1028 23ff  KCM9FRUL30T7
+		1028 2400  KCM9FRUL61T4
+		1028 2401  KCM9XRUL1T92
+		1028 2402  KCM9XRUL3T84
+		1028 2403  KCM9XRUL7T68
+		1028 2404  KCM9XRUL15T3
+		1028 2405  KCM9XRUL30T7
+		1028 2406  KCM9XRUL61T4
+		1028 2407  KCM9FVUL1T60
+		1028 2408  KCM9FVUL3T20
+		1028 2409  KCM9FVUL6T40
+		1028 240a  KCM9FVUL12T8
+		1028 240b  KCM9XVUL1T60
+		1028 240c  KCM9XVUL3T20
+		1028 240d  KCM9XVUL6T40
+		1028 240e  KCM9XVUL12T8
+	0036  NVMe SSD Controller CD9P U.2
+		1028 23d5  KCD9DPUG1T92
+		1028 23d6  KCD9DPUG3T84
+		1028 23d7  KCD9DPUG7T68
+		1028 23d8  KCD9DPUG15T3
+		1028 23d9  KCD9DPUG30T7
+		1028 23da  KCD9DPUG61T4
+		1028 23db  KCD9XPUG1T92
+		1028 23dc  KCD9XPUG3T84
+		1028 23dd  KCD9XPUG7T68
+		1028 23de  KCD9XPUG15T3
+		1028 23df  KCD9XPUG30T7
+		1028 23e0  KCD9XPUG61T4
+		1028 23e1  KCD9DPUG1T60
+		1028 23e2  KCD9DPUG3T20
+		1028 23e3  KCD9DPUG6T40
+		1028 23e4  KCD9DPUG12T8
+		1028 23e5  KCD9XPUG1T60
+		1028 23e6  KCD9XPUG3T20
+		1028 23e7  KCD9XPUG6T40
+		1028 23e8  KCD9XPUG12T8
+	0037  NVMe SSD Controller CD9P E3.S
+		1028 23e9  KCD9DPJE1T92
+		1028 23ea  KCD9DPJE3T84
+		1028 23eb  KCD9DPJE7T68
+		1028 23ec  KCD9DPJE15T3
+		1028 23ed  KCD9DPJE30T7
+		1028 23ee  KCD9XPJE1T92
+		1028 23ef  KCD9XPJE3T84
+		1028 23f0  KCD9XPJE7T68
+		1028 23f1  KCD9XPJE15T3
+		1028 23f2  KCD9XPJE30T7
+		1028 23f3  KCD9DPJE1T60
+		1028 23f4  KCD9DPJE3T20
+		1028 23f5  KCD9DPJE6T40
+		1028 23f6  KCD9DPJE12T8
+		1028 23f7  KCD9XPJE1T60
+		1028 23f8  KCD9XPJE3T20
+		1028 23f9  KCD9XPJE6T40
+		1028 23fa  KCD9XPJE12T8
+	003a  NVMe SSD Controller BG8 (DRAM-less)
+	003b  Exceria Basic NVMe SSD (DRAM-less)
+	003d  LC9 E3.L NVMe SSD
+		1028 244f  RLC9GZV245T
+		1028 2450  RLC9CZV245T
+	003e  LC9 E3.S NVMe SSD
+	003f  LC9 U.2 NVMe SSD
+	0042  NVMe SSD Controller LD4
 1e17  Arnold & Richter Cine Technik GmbH & Co. Betriebs KG
 1e18  Beijing GuangRunTong Technology Development Co.,Ltd
 1e24  Squirrels Research Labs
@@ -27667,6 +28563,8 @@
 1e30  Sophgo
 	1684  BM1684 [Sophon Series Deep Learning Accelerator]
 	2042  SG2042 Root Complex
+# https://www.sord.co.jp/
+1e31  SORD CORPORATION
 1e36  Shanghai Enflame Technology Co. Ltd
 	0001  T10 [CloudBlazer]
 	0002  T11 [CloudBlazer]
@@ -27709,6 +28607,8 @@
 		1e3b 0013  Enterprise NVMe SSD U.2 3.20TB (R5302)
 		1e3b 0027  Enterprise NVMe SSD U.2 61.44TB (J5060)
 		1e3b 0028  Enterprise NVMe SSD U.2 61.44TB (J5060D)
+		1e3b 0029  Enterprise NVMe SSD U.2 15.36TB (J5060)
+		1e3b 002a  Enterprise NVMe SSD U.2 15.36TB (J5060D)
 		1e3b 0030  Enterprise NVMe SSD U.2 3.84TB (J5100)
 		1e3b 0031  Enterprise NVMe SSD U.2 7.68TB (J5100)
 		1e3b 0032  Enterprise NVMe SSD U.2 15.36TB (J5100)
@@ -27741,6 +28641,8 @@
 		1e3b 0069  Enterprise NVMe SSD U.2 3.20TB (R5301D)
 		1e3b 006c  Enterprise NVMe SSD U.2 1.92TB (R5101)
 		1e3b 006d  Enterprise NVMe SSD U.2 1.60TB (J5301)
+		1e3b 0083  Enterprise NVMe SSD AIC 1.6TB (J5310)
+		1e3b 0096  Enterprise NVMe SSD AIC 1.92TB (J5110)
 		1e3b 00b9  Enterprise NVMe SSD U.2 25.60TB
 		1e3b 00be  Enterprise NVMe SSD U.2 30.72TB
 		1e3b 00c1  Enterprise NVMe SSD U.2 25.60TB
@@ -27763,7 +28665,7 @@
 		1e3b 00e9  Enterprise NVMe SSD U.2 6.40TB (J5301)
 		1e3b 00ea  Enterprise NVMe SSD U.2 3.20TB (J5301D)
 		1e3b 00eb  Enterprise NVMe SSD U.2 6.40TB (J5301D)
-		1e3b 00ec  Enterprise NVMe SSD U.2 30.72TB (J5101)
+		1e3b 00ec  Enterprise NVMe SSD U.2 7.68TB (J5100)
 		1e3b 00ed  Enterprise NVMe SSD U.2 30.72TB (R5101)
 		1e3b 00ee  Enterprise NVMe SSD U.2 15.36B (J5101)
 		1e3b 00ef  Enterprise NVMe SSD U.2 12.80TB (J5301)
@@ -27773,18 +28675,92 @@
 		1e3b 00f3  Enterprise NVMe SSD U.2 3.20TB (X2900)
 		1e3b 00f5  Enterprise NVMe SSD U.2 0.40TB (X2900P)
 		1e3b 00f6  Enterprise NVMe SSD U.2 0.80TB (X2900P)
+		1e3b 00f8  Enterprise NVMe SSD U.2 122.88TB
+		1e3b 00f9  Enterprise NVMe SSD U.2 122.88TB (J5060D)
+		1e3b 00fc  Enterprise NVMe SSD U.2 7.68TB (J5000D)
 	0800  NVMe SSD Controller DP800
-		1e3b 0001  Enterprise NVMe SSD U.2 3.84TB(R6100)
-		1e3b 0007  Enterprise NVMe SSD U.2 15.36TB (R6100)
-		1e3b 000a  Enterprise NVMe SSD U.2 3.20TB (R6300)
-		1e3b 000d  Enterprise NVMe SSD U.2 6.40TB (R6300)
-		1e3b 0010  Enterprise NVMe SSD U.2 12.80TB (R6300)
-		1e3b 0018  Enterprise NVMe SSD U.2 3.84TB (R6100C)
-		1e3b 0019  Enterprise NVMe SSD U.2 7.68TB (R6100C)
-		1e3b 001a  Enterprise NVMe SSD U.2 3.20TB (R6300C)
-		1e3b 001b  Enterprise NVMe SSD U.2 6.40TB (R6300C)
-		1e3b 001c  Enterprise NVMe SSD U.2 7.68TB (R6100)
+		1e3b 0001  Enterprise NVMe SSD U.2 3.84TB (R6101)
+		1e3b 0003  Enterprise NVMe SSD U.2 7.68TB (R6100)
+		1e3b 0004  Enterprise NVMe SSD U.2 7.68TB (R6101)
+		1e3b 0006  Enterprise NVMe SSD U.2 15.36TB (R6100)
+		1e3b 0007  Enterprise NVMe SSD U.2 15.36TB (R6101)
+		1e3b 000a  Enterprise NVMe SSD U.2 3.2TB (R6301)
+		1e3b 000c  Enterprise NVMe SSD U.2 6.4TB (R6300)
+		1e3b 000d  Enterprise NVMe SSD U.2 6.4TB (R6301)
+		1e3b 000f  Enterprise NVMe SSD U.2 12.8TB (R6300)
+		1e3b 0010  Enterprise NVMe SSD U.2 12.8TB (R6301)
+		1e3b 0018  Enterprise NVMe SSD U.2 3.84TB (R6101C)
+		1e3b 0019  Enterprise NVMe SSD U.2 7.68TB (R6101C)
+		1e3b 001a  Enterprise NVMe SSD U.2 3.2TB (R6301C)
+		1e3b 001b  Enterprise NVMe SSD U.2 6.4TB (R6301C)
 		1e3b 001d  Enterprise NVMe SSD U.2 3.84TB (R6101)
+		1e3b 001e  Enterprise NVMe SSD U.2 3.84TB (R6100)
+		1e3b 001f  Enterprise NVMe SSD U.2 1.92TB (R6101)
+		1e3b 0024  Enterprise NVMe SSD U.2 3.2TB (R6300)
+		1e3b 0027  Enterprise NVMe SSD U.2 7.68TB (R6101)
+		1e3b 0028  Enterprise NVMe SSD U.2 15.36TB (R6101)
+		1e3b 002a  Enterprise NVMe SSD U.2 6.4TB (R6301)
+		1e3b 002b  Enterprise NVMe SSD U.2 12.8TB (R6301)
+		1e3b 002c  Enterprise NVMe SSD U.2 30.72TB (R6101)
+		1e3b 002d  Enterprise NVMe SSD U.2 25.6TB (R6301)
+		1e3b 002e  Enterprise NVMe SSD U.2 15.36TB (R6000)
+		1e3b 002f  Enterprise NVMe SSD U.2 30.72TB (R6000)
+		1e3b 0034  Enterprise NVMe SSD U.2 30.72TB (R6060)
+		1e3b 0035  Enterprise NVMe SSD U.2 61.44TB (R6060)
+		1e3b 0036  Enterprise NVMe SSD U.2 122.88TB (R6060)
+		1e3b 003b  Enterprise NVMe SSD U.2 1.6TB (R6301)
+		1e3b 003f  Enterprise NVMe SSD U.2 7.68TB (R6100)
+		1e3b 0040  Enterprise NVMe SSD U.2 15.36TB (R6100)
+		1e3b 0041  Enterprise NVMe SSD U.2 6.4TB (R6300)
+		1e3b 0042  Enterprise NVMe SSD U.2 12.8TB (R6300)
+		1e3b 0043  Enterprise NVMe SSD U.2 1.92TB (R6101)
+		1e3b 0049  Enterprise NVMe SSD U.2 1.92TB (R6101)
+		1e3b 0051  Enterprise NVMe SSD U.2 7.68TB (R6101)
+		1e3b 0052  Enterprise NVMe SSD U.2 15.36TB (R6101)
+		1e3b 0054  Enterprise NVMe SSD U.2 6.4TB (R6301)
+		1e3b 0055  Enterprise NVMe SSD U.2 12.8TB (R6301)
+		1e3b 0058  Enterprise NVMe SSD U.2 0.8TB (X5900P)
+		1e3b 0059  Enterprise NVMe SSD U.2 15.36TB (R6060)
+		1e3b 005a  Enterprise NVMe SSD U.2 3.84TB (R6101)
+		1e3b 005c  Enterprise NVMe SSD U.2 3.84TB (R6101)
+		1e3b 0060  Enterprise NVMe SSD U.2 15.36TB (R6000)
+		1e3b 0061  Enterprise NVMe SSD U.2 30.72TB (R6000)
+		1e3b 0062  Enterprise NVMe SSD U.2 15.36TB (R6060)
+		1e3b 0063  Enterprise NVMe SSD U.2 30.72TB (R6060)
+		1e3b 0064  Enterprise NVMe SSD U.2 61.44TB (R6060)
+		1e3b 0065  Enterprise NVMe SSD U.2 122.88TB (R6060)
+		1e3b 0067  Enterprise NVMe SSD U.2 7.68TB (R6101)
+		1e3b 0068  Enterprise NVMe SSD U.2 15.36TB (R6101)
+		1e3b 0069  Enterprise NVMe SSD U.2 6.4TB (R6301)
+		1e3b 006a  Enterprise NVMe SSD U.2 12.8TB (R6301)
+		1e3b 0070  Enterprise NVMe SSD U.2 7.68TB (R6101)
+		1e3b 0071  Enterprise NVMe SSD U.2 15.36TB (R6101)
+		1e3b 0072  Enterprise NVMe SSD U.2 6.4TB (R6301)
+		1e3b 0073  Enterprise NVMe SSD U.2 12.8TB (R6301)
+		1e3b 0077  Enterprise NVMe SSD U.2 3.84TB (R6100)
+		1e3b 0078  Enterprise NVMe SSD U.2 3.2TB (R6300)
+		1e3b 0079  Enterprise NVMe SSD U.2 3.84TB (R6100)
+		1e3b 007a  Enterprise NVMe SSD U.2 3.2TB (R6300)
+		1e3b 007b  Enterprise NVMe SSD U.2 30.72TB (R6101)
+		1e3b 007c  Enterprise NVMe SSD U.2 25.6TB (R6301)
+		1e3b 007d  Enterprise NVMe SSD U.2 1.6TB (X5900P)
+		1e3b 007e  Enterprise NVMe SSD U.2 0.8TB (X5900P)
+		1e3b 007f  Enterprise NVMe SSD U.2 1.6TB (X5900P)
+		1e3b 0143  Enterprise NVMe SSD U.2 1.92TB (R6101)
+		1e3b 0144  Enterprise NVMe SSD U.2 1.6TB (R6301)
+		1e3b 0149  Enterprise NVMe SSD U.2 1.92TB (R6101)
+		1e3b 014c  Enterprise NVMe SSD U.2 1.6TB (R6301)
+		1e3b 015a  Enterprise NVMe SSD U.2 3.84TB (R6101)
+		1e3b 015b  Enterprise NVMe SSD U.2 3.2TB (R6301)
+		1e3b 015c  Enterprise NVMe SSD U.2 3.84TB (R6101)
+		1e3b 015d  Enterprise NVMe SSD U.2 3.2TB (R6301)
+		1e3b 2000  Enterprise NVMe SSD E1.S 9.5 3.2TB (X5900P)
+		1e3b 3001  Enterprise NVMe SSD E3.S 3.84TB (R6100)
+		1e3b 3002  Enterprise NVMe SSD E3.S 7.68TB (R6100)
+		1e3b 3003  Enterprise NVMe SSD E3.S 15.36TB (R6100)
+		1e3b 3004  Enterprise NVMe SSD E3.S 3.2TB (R6300)
+		1e3b 3005  Enterprise NVMe SSD E3.S 6.4TB (R6300)
+		1e3b 3006  Enterprise NVMe SSD E3.S 12.8TB (R6300)
 	1098  Haishen3 NVMe SSD
 		1e3b 0001  Enterprise NVMe SSD U.2 0.8TB (H2100)
 		1e3b 0002  Enterprise NVMe SSD U.2 0.96TB (H2200)
@@ -27861,7 +28837,7 @@
 		1e3b 3001  Ethernet Network Adapter DN200-X1V for 10GbE SFP+ 2-port
 	3002  Ethernet Controller DN200 Series Virtual Function
 	300c  Ethernet RAID Combo Controller DN200C for 1GbE
-		1e3b 300c  Ethernet RAID Combo Adapter DN200C-G2V for 1GbE 4-port
+		1e3b 300c  Ethernet RAID Combo Adapter DN200C-G2 for 1GbE 4-port
 	300d  Ethernet RAID Combo Controller DN200C Series Virtual Function
 	5001  RAID Controller DP808A
 	5002  RAID Controller DP808AL
@@ -27873,19 +28849,22 @@
 	50d0  NVME RAID Card DP800
 	50d1  Flexraid6 NVMeRAID
 1e3d  Burlywood, Inc
+1e3e  Shanghai Iluvatar CoreX Semiconductor Co., Ltd.
 1e43  MaxLinear Inc
 	8904  MxL8904
 	8906  MxL8906
 	8908  MxL8908
 1e44  Valve Software
-# the actual PCI-SIG member is Elektrobit, a daughter company of Continental
-1e48  Continental
+# The actual PCI-SIG member is Elektrobit, a daughter company of Aumovio (ex Continental)
+1e48  Aumovio
 1e49  Yangtze Memory Technologies Co.,Ltd
 	0001  ZHITAI PC005 NVMe SSD
 	0021  ZHITAI TiPro5000 NVMe SSD
 	0041  ZHITAI TiPro7000
 	0071  ZHITAI TiPlus7100
 	0081  ZHITAI Ti600 NVMe SSD
+	0090  ZHITAI TiPro9000 NVMe SSD
+	00a1  ZHITAI TiPlus7100s NVMe SSD (DRAM-less)
 # YMTC
 	1001  PC005 NVMe SSD
 	1011  PC210 M.2 2280 NVMe SSD
@@ -27894,7 +28873,16 @@
 	1033  PC300 M.2 2242 NVMe SSD (DRAM-less)
 	1071  PC411 M.2 2280 NVMe SSD (DRAM-less)
 	1073  PC411 M.2 2242 NVMe SSD (DRAM-less)
+	1078  PE321 U.2 NVMe SSD
 	1081  PC41Q M.2 2280 NVMe SSD (DRAM-less)
+	1083  PC41Q M.2 2242 NVMe SSD (DRAM-less)
+	1101  PC450 M.2 2280 NVMe SSD (DRAM-less)
+	1103  PC450 M.2 2242 NVMe SSD (DRAM-less)
+	1111  PC42Q M.2 2280 NVMe SSD (DRAM-less)
+	1113  PC42Q M.2 2242 NVMe SSD (DRAM-less)
+	1121  PC550 M.2 2280 NVMe SSD
+	1123  PC550 M.2 2242 NVMe SSD
+	1a28  PE511 U.2 NVMe SSD
 1e4b  MAXIO Technology (Hangzhou) Ltd.
 	1001  NVMe SSD Controller MAP1001
 	1002  NVMe SSD Controller MAP1002 (DRAM-less)
@@ -27905,15 +28893,21 @@
 	1602  NVMe SSD Controller MAP1602 (DRAM-less)
 	1608  NVMe SSD Controller MAP1608 (DRAM-less)
 1e4c  GSI Technology
-	0010  Associative Processing Unit [Leda]
+	0010  Gemini-I
+		1e4c 0010  Leda-E
 		1e4c 0120  SE120
-	0020  Associative Processing Unit [Leda-2]
+	0020  Gemini-II
+		1e4c 0011  Leda-E2 rev 1.1
+		1e4c 0020  G2-Edge
 1e50  IP3 Tech (HK) Limited
 1e52  Tenstorrent Inc
 	401e  Wormhole
 		1e52 0014  n300
 		1e52 0018  n150
 	b140  Blackhole
+		1e52 0040  p150a
+		1e52 0041  p150b
+		1e52 0043  p100a
 	faca  Grayskull
 		1e52 0003  e150
 		1e52 0007  e75
@@ -27960,8 +28954,10 @@
 		1e81 a214  NVMe SSD UHXXXa series U.2 6400GB
 		1e81 f123  NVMe SSD TP6500 series U.2 3840GB
 	6206  AM620 NVMe SSD
+	6a02  AM6A0 NVMe SSD (DRAM-less)
+	6c14  RPEYJ1T24 NVMe SSD (DRAM-less)
 1e83  Huaqin Technology Co.Ltd
-1e85  Heitec AG
+1e85  HEITEC AG
 1e89  ID Quantique SA
 	0002  Quantis-PCIe-40M
 	0003  Quantis-PCIe-240M
@@ -27969,16 +28965,30 @@
 # aka SED Systems
 1e94  Calian SED
 1e95  Solid State Storage Technology Corporation
-	1000  XA1-311024 NVMe SSD M.2
+	1000  XA1 Series NVMe SSD M.2 (DRAM-less)
 	1001  CA6-8D512 NVMe SSD M.2
 	1002  NVMe SSD [3DNAND] 2.5" U.2 (LJ1)
 		1e95 1101  NVMe SSD [3DNAND] 2.5" U.2 (LJ1)
 		1ea0 5636  TP1500 Series U.2 NVMe Datacenter SSD
 	1003  CLR-8W512 NVMe SSD M.2 (DRAM-less)
 	1005  PLEXTOR M10P(GN) NVMe SSD M.2
-	1007  CL4-8D512 NVMe SSD M.2 (DRAM-less)
+	1006  CA8 Series NVMe SSD M.2
+	1007  CL4 Series NVMe SSD M.2 (DRAM-less)
 	1008  CL5-8D512 NVMe SSD M.2 (DRAM-less)
+	100b  XB2-311024 NVMe SSD M.2 (DRAM-less)
 	100c  CL6 Series NVMe SSD M.2 (DRAM-less)
+	100d  PJ1 Series NVMe SSD
+		1e95 0000  M.2 2280 480 GB
+		1e95 0001  M.2 2280 960 GB
+		1e95 0002  M.2 2280 1920 GB
+		1e95 0003  M.2 22110 3840 GB
+		1e95 0004  U.2 1920 GB
+		1e95 0005  U.2 3840 GB
+		1e95 0006  U.2 7680 GB
+		1e95 0007  U.2 1600 GB
+		1e95 0008  U.2 3200 GB
+		1e95 0009  U.2 6400 GB
+	100f  EJ5-2W3840 NVMe SSD U.2
 	1010  CX3 Series NVMe SSD
 		1e95 0000  M.2 2280 480 GB
 		1e95 0001  M.2 2280 960 GB
@@ -28074,8 +29084,12 @@
 		1ec8 12a2  Fantasy I Device
 	8810  Fantasy I
 		1ec8 12a2  Fantasy I Device
+# Also in the Windows driver INF installation file.
+	8811  Fantasy I-V
+	8820  Fantasy III
 	8900  GR308
 	8902  GR3 Audio
+	8904  GR308
 	9800  Fantasy II
 		1ec8 12a2  Fantasy II Device
 	9802  Fantasy II
@@ -28088,11 +29102,16 @@
 1ec9  Wingtech Group(HongKong)Limited
 1eca  Lightmatter
 	0000  Envise-B
+# This Vendor ID 1ecc is officially allocated to Sunrise AI Inc. by PCI-SIG.
+1ecc  Sunrise AI Inc.
+# This DID 0200 corresponds to the standard PCIe version of Sun S2 GPU.
+	0200  Sun S2 Graphics Controller[Sun S2-X1 PCIe]
 1ed0  Hosin Global Electronics
 	2283  Patriot P300 NVMe SSD (DRAM-less)
 1ed2  FuriosaAI, Inc.
 	0000  Warboy
 	0001  RNGD
+	0002  RNGD-Plus
 	2222  RNGD-S
 1ed3  Yeston
 1ed5  Moore Threads Technology Co.,Ltd
@@ -28180,6 +29199,38 @@
 		1ee4 0625  NVMe SSD U.2 1.6TB (P8128Z3)
 		1ee4 0626  NVMe SSD U.2 3.2TB (P8128Z3)
 		1ee4 0627  NVMe SSD U.2 6.4TB (P8128Z3)
+		1ee4 0715  NVMe SSD U.2 1.92TB (P8118Z4)
+		1ee4 0716  NVMe SSD U.2 3.84TB (P8118Z4)
+		1ee4 0717  NVMe SSD U.2 7.68TB (P8118Z4)
+		1ee4 0718  NVMe SSD U.2 15.36TB (P8118Z4)
+		1ee4 0725  NVMe SSD U.2 1.6TB (P8118Z4)
+		1ee4 0726  NVMe SSD U.2 3.2TB (P8118Z4)
+		1ee4 0727  NVMe SSD U.2 6.4TB (P8118Z4)
+		1ee4 0728  NVMe SSD U.2 12.8TB (P8118Z4)
+		1ee4 0815  NVMe SSD U.2 1.92TB (P8118H4)
+		1ee4 0816  NVMe SSD U.2 3.84TB (P8118H4)
+		1ee4 0817  NVMe SSD U.2 7.68TB (P8118H4)
+		1ee4 0825  NVMe SSD U.2 1.6TB (P8118H4)
+		1ee4 0826  NVMe SSD U.2 3.2TB (P8118H4)
+		1ee4 0827  NVMe SSD U.2 6.4TB (P8118H4)
+		1ee4 0915  NVMe SSD U.2 1.92TB (P8118E2)
+		1ee4 0916  NVMe SSD U.2 3.84TB (P8118E2)
+		1ee4 0917  NVMe SSD U.2 7.68TB (P8118E2)
+		1ee4 0925  NVMe SSD U.2 1.6TB (P8118E2)
+		1ee4 0926  NVMe SSD U.2 3.2TB (P8118E2)
+		1ee4 0927  NVMe SSD U.2 6.4TB (P8118E2)
+		1ee4 0a15  NVMe SSD U.2 1.92TB (P8118H2)
+		1ee4 0a16  NVMe SSD U.2 3.84TB (P8118H2)
+		1ee4 0a17  NVMe SSD U.2 7.68TB (P8118H2)
+		1ee4 0a25  NVMe SSD U.2 1.6TB (P8118H2)
+		1ee4 0a26  NVMe SSD U.2 3.2TB (P8118H2)
+		1ee4 0a27  NVMe SSD U.2 6.4TB (P8118H2)
+		1ee4 0b15  NVMe SSD U.2 1.92TB (P8118H3)
+		1ee4 0b16  NVMe SSD U.2 3.84TB (P8118H3)
+		1ee4 0b17  NVMe SSD U.2 7.68TB (P8118H3)
+		1ee4 0b25  NVMe SSD U.2 1.6TB (P8118H3)
+		1ee4 0b26  NVMe SSD U.2 3.2TB (P8118H3)
+		1ee4 0b27  NVMe SSD U.2 6.4TB (P8118H3)
 		1ee4 3013  NVMe SSD AIC 480GB (P8118E)
 		1ee4 3014  NVMe SSD AIC 960GB (P8118E)
 		1ee4 3015  NVMe SSD AIC 1.92TB (P8118E)
@@ -28228,6 +29279,14 @@
 		1ee4 3625  NVMe SSD AIC 1.6TB (P8128Z3)
 		1ee4 3626  NVMe SSD AIC 3.2TB (P8128Z3)
 		1ee4 3627  NVMe SSD AIC 6.4TB (P8128Z3)
+		1ee4 3715  NVMe SSD AIC 1.92TB (P8118Z4)
+		1ee4 3716  NVMe SSD AIC 3.84TB (P8118Z4)
+		1ee4 3717  NVMe SSD AIC 7.68TB (P8118Z4)
+		1ee4 3718  NVMe SSD AIC 15.36TB (P8118Z4)
+		1ee4 3725  NVMe SSD AIC 1.6TB (P8118Z4)
+		1ee4 3726  NVMe SSD AIC 3.2TB (P8118Z4)
+		1ee4 3727  NVMe SSD AIC 6.4TB (P8118Z4)
+		1ee4 3728  NVMe SSD AIC 12.8TB (P8118Z4)
 		1ee4 abcd  NVMe SSD U.2
 	1181  PETA8118 NVMe E1S Series
 		1ee4 2015  NVMe SSD E1.S 1.92TB (P8118E)
@@ -28272,6 +29331,14 @@
 		1ee4 2625  NVMe SSD E1.S 1.6TB (P8128Z3)
 		1ee4 2626  NVMe SSD E1.S 3.2TB (P8128Z3)
 		1ee4 2627  NVMe SSD E1.S 6.4TB (P8128Z3)
+		1ee4 2715  NVMe SSD E1.S 1.92TB (P8118Z4)
+		1ee4 2716  NVMe SSD E1.S 3.84TB (P8118Z4)
+		1ee4 2717  NVMe SSD E1.S 7.68TB (P8118Z4)
+		1ee4 2718  NVMe SSD E1.S 15.36TB (P8118Z4)
+		1ee4 2725  NVMe SSD E1.S 1.6TB (P8118Z4)
+		1ee4 2726  NVMe SSD E1.S 3.2TB (P8118Z4)
+		1ee4 2727  NVMe SSD E1.S 6.4TB (P8118Z4)
+		1ee4 2728  NVMe SSD E1.S 12.8TB (P8118Z4)
 	1182  PETA8118 NVMe M2 Series
 		1ee4 1013  NVMe SSD M.2 480GB (P8118E)
 		1ee4 1014  NVMe SSD M.2 960GB (P8118E)
@@ -28337,6 +29404,22 @@
 		1ee4 1625  NVMe SSD M.2 1.6TB (P8128Z3)
 		1ee4 1626  NVMe SSD M.2 3.2TB (P8128Z3)
 		1ee4 1627  NVMe SSD M.2 6.4TB (P8128Z3)
+		1ee4 1714  NVMe SSD M.2 960GB (P8118Z4)
+		1ee4 1715  NVMe SSD M.2 1.92TB (P8118Z4)
+		1ee4 1716  NVMe SSD M.2 3.84TB (P8118Z4)
+		1ee4 1717  NVMe SSD M.2 7.68TB (P8118Z4)
+		1ee4 1724  NVMe SSD M.2 800GB (P8118Z4)
+		1ee4 1725  NVMe SSD M.2 1.6TB (P8118Z4)
+		1ee4 1726  NVMe SSD M.2 3.2TB (P8118Z4)
+		1ee4 1727  NVMe SSD M.2 6.4TB (P8118Z4)
+		1ee4 1814  NVMe SSD M.2 960GB (P8118H4)
+		1ee4 1815  NVMe SSD M.2 1.92TB (P8118H4)
+		1ee4 1816  NVMe SSD M.2 3.84TB (P8118H4)
+		1ee4 1817  NVMe SSD M.2 7.68TB (P8118H4)
+		1ee4 1824  NVMe SSD M.2 800GB (P8118H4)
+		1ee4 1825  NVMe SSD M.2 1.6TB (P8118H4)
+		1ee4 1826  NVMe SSD M.2 3.2TB (P8118H4)
+		1ee4 1827  NVMe SSD M.2 6.4TB (P8118H4)
 1ee9  SUSE LLC
 1eec  Viscore Technologies Ltd
 	0102  VSE250231S Dual-port 10Gb/25Gb Ethernet PCIe
@@ -28346,6 +29429,7 @@
 	10a1  XDX110 Audio Controller
 	10a2  XDX110M
 	10a4  XDX E1100
+	1100  XDX110
 	1140  XDX120
 	1142  XDX120M
 	1144  XDX E1200
@@ -28377,6 +29461,7 @@
 	1810  XDX TJ01 Audio
 	1820  XDX TJ02 Audio
 	1830  XDX TJ03 Audio
+	2100  XDX290
 1ef6  GrAI Matter Labs
 1ef7  Shenzhen Gunnir Technology Development Co., Ltd
 1efb  Flexxon Pte Ltd
@@ -28393,11 +29478,20 @@
 	1221  RBLN-CA22 (VF)
 	1250  RBLN-CA25 (PF)
 	1251  RBLN-CA25 (VF)
+	2030  RBLN-CR03 (PF)
+	2031  RBLN-CR03 (VF)
+	2130  RBLN-CR13 (PF)
+	2131  RBLN-CR13 (VF)
+	2230  RBLN-CR23 (PF)
+	2231  RBLN-CR23 (VF)
 1f02  Beijing Dayu Technology
 1f03  Shenzhen Shichuangyi Electronics Co., Ltd
 	1202  MAP1202-Based NVMe SSD (DRAM-less)
+	1608  SCY C5000 NVMe SSD (DRAM-less)
 	2262  SM2262EN-based OEM SSD
-	2263  SM2263XT-Base NVMe SSD
+	2263  SM2263XT-Based NVMe SSD (DRAM-less)
+	2268  SM2268XT-Based NVMe SSD (DRAM-less)
+	2269  SM2269XT-Based NVMe SSD (DRAM-less)
 	5216  IG5216-based NVMe SSD (DRAM-less)
 	5220  IG5220-Based NVMe SSD
 	5236  IG5236-Based NVMe SSD
@@ -28411,19 +29505,47 @@
 		1f0f 0001  D1055AS vDPA Ethernet Controller
 	1042  D1055AS vDPA Storage Controller
 		1f0f 0001  D1055AS vDPA Storage Controller
+	1045  D1205CQ vPDA Ethernet Controller
+		1f0f 0001  D1205CQ vPDA Ethernet Controller
+	1046  D1205CQ vPDA Storage Controller
+		1f0f 0001  D1205CQ vPDA Storage Controller
+	1047  D1205CQ RDMA Ethernet Controller
+		1f0f 0001  D1205CQ RDMA Ethernet Controller
 	1220  D1055AS Ethernet Controller
 	1221  D1055AS Ethernet Controller
 	1222  D1055AS Ethernet Controller
 	1223  D1055AS Ethernet Controller
+	1224  D1205CQ Ethernet Controller
+		1f0f 0001  D1205CQ Ethernet Controller
+	1225  D1205CQ Ethernet Controller
+		1f0f 0001  D1205CQ Ethernet Controller
+	1226  D1205CQ Ethernet Controller
+		1f0f 0001  D1205CQ Ethernet Controller
+	1227  D1205CQ Ethernet Controller
+		1f0f 0001  D1205CQ Ethernet Controller
+	1228  D1205CQ Ethernet Controller
+		1f0f 0001  D1205CQ Ethernet Controller
 	1600  M16104 Family
-		1f0f 0001  M16104 Family
+		1f0f 0001  N1045XS, Quad-port 10GbE, PCIe 3.0 x8
 	1601  M16104 Family Virtual Function
 		1f0f 0001  M16104 Family Virtual Function
+	1610  M16140 Family
+		1f0f 0001  S1405WQ, Single-port 400GbE, PCIe5.0 x16
+		1f0f 0002  S1406VQ, Dual-port 200GbE, PCIe5.0 x16
+	1800  M16104 Family
+		1f0f 0001  CXP-6, Quad-port, PCIe 3.0 x4, Fan
+		1f0f 0002  CXP-12, Quad-port, PCIe 3.0 x8, Fan
+	1801  M16105 Family
+		1f0f 0001  CXP-31, Dual-port, PCIe 4.0 x8, Fan
 	1a00  M16104 Family
-		1f0f 0001  M16104 Family
+		1f0f 0001  N1045XT, Quad-port 10GbE, PCIe 3.0 x8
+		1f0f 0002  N1045XT, Quad-port 10GbE, PCIe 3.0 x8, Fan
 	1a01  M16104 Family Virtual Function
 		1f0f 0001  M16104 Family Virtual Function
+	1a02  M16102 Family
+		1f0f 0001  N1025XT, Dual-port 10GbE, PCIe 3.0 x4, Fan
 	2022  D1055AS PCI Express Switch Upstream Port
+	2023  D1205CQ PCI Express Switch Upstream Port
 	3403  M18110 Family
 	3404  M18110 Lx Family
 	3405  M18110 Family BASE-T
@@ -28441,10 +29563,32 @@
 	3411  M18000 Family BASE-T OCP
 	3412  M18000 Lx Family BASE-T OCP
 	3413  M18000 Family Virtual Function
+	3502  M18305 Family
+		1f0f 0001  S2055AS, 2x 25GbE, SFP28, PCIe 4.0 x8
+		1f0f 0002  S2025XS, 2x 10GbE, SFP+, PCIe 4.0 x8
+	3504  M18305 Family BASE-T
+		1f0f 0001  S2025XT, 2x 10GbE, Base-T, PCIe 4.0 x8
+		1f0f 0002  S2025XT, 2x 10GbE, BASE-T, PCIe 4.0 x4, Fan
+		1f0f 0003  S2045XT, 4x 10GbE, Base-T, PCIe 4.0 x8
+		1f0f 0004  S2045XT, 4x 10GbE, BASE-T, PCIe 4.0 x8, Fan
+	350a  M18305 Family Virtual Function
+		1f0f 0001  M18305 Family Virtual Function
 	9088  D1055AS PCI Express Switch Downstream Port
+	9089  D1205CQ PCI Express Switch Downstream Port
 1f16  XConn Technologies
-# XConn XC50256 CXL2.0/PCIe5.0 switch
-	c500  XC50256
+	c500  XC50256 CXL2.0 Switch
+	c510  XC51256 PCIe 5.0 Switch
+	c601  C60064 CXL 3.1 Switch
+	c602  XC60256 CXL 3.1 Switch
+	c603  XC60064 CXL 3.1 Switch
+	c604  XC60148 CXL 3.1 Switch
+	c605  XC60260 CXL 3.1 Switch
+	c611  XC61064 PCIe 6.1 Switch
+	c612  XC61256 PCIe 6.1 Switch
+	c613  XC61064 PCIe 6.2 Switch
+	c614  XC61148 PCIe 6.2 Switch
+	c615  XC61260 PCIe 6.2 Switch
+	c640  XC61064 PCIe 6.2 Switch
 1f17  Zettastone Technology
 1f18  c-payne GmbH
 	0001  PCIe gen4 Switch Backplane 5x x16 - 4W
@@ -28469,7 +29613,11 @@
 		1f2f 6116  KM560 U.2 3.84TB NVMe SSD
 		1f2f 6118  KM560 U.2 7.68TB NVMe SSD
 1f31  Nextorage
-	4512  Nextorage NE1N NVMe SSD
+	4512  NE1N NVMe SSD
+	451b  NN4LE NVMe SSD (DRAM-less)
+	4622  NEM-PAC NVMe SSD (DRAM-less)
+1f32  Wuhan YuXin Semiconductor Co., Ltd.
+	ed55  U800G NVMe SSD
 1f3f  3SNIC Ltd
 	2100  SSSHBA SAS/SATA HBA
 		1f3f 0120  HBA 32 Ports
@@ -28510,47 +29658,60 @@
 		1f3f 00a1  Dual Port 100GE SDI5.1
 1f40  Netac Technology Co.,Ltd
 	0001  PCIe 4 NVMe SSD (DRAM-less)
-	1202  PCIe 3 NVMe SSD (DRAM-less)
-	1602  PCIe 4 NVMe SSD (DRAM-less)
+	1202  NV3000 NVMe SSD (DRAM-less)
+	1602  NV7000-t NVMe SSD (DRAM-less)
 	1f40  PCIe 4 NVMe SSD (DRAM-less)
 	2263  PCIe 3 SM based NVMe SSD (DRAM-less)
 	5216  PCIe 3 NVMe SSD (DRAM-less)
-	5236  PCIe 4 INNOGRIT based NVMe SSD
+	5236  NV7000 NVMe SSD
 	5765  PCIe 3 NVMe SSD (DRAM-less)
 1f44  VVDN Technologies Private Limited
-1f47  YUSUR Technology Co., Ltd.
-	1001  FLEXFLOW-2200T Ethernet Controller
-		1f47 0001  Ethernet 10G 2P FLEXFLOW-2200T
-		1f47 0002  Ethernet 25G 2P FLEXFLOW-2200T
-		1f47 0003  Ethernet 40G 2P FLEXFLOW-2200T
+1f47  YUSUR Technology
+	1001  K2-Pro Family [FLEXFLOW-2200T]
+		1f47 0001  FLEXFLOW-2200T 2*10GE Ethernet Adapter
+		1f47 0002  FLEXFLOW-2200T 2*25GE Ethernet Adapter
+		1f47 0003  FLEXFLOW-2200T 2*40GE Ethernet Adapter
 		1f47 0004  Ethernet 100G 1P FLEXFLOW-2200T
-		1f47 0005  Ethernet 100G 2P FLEXFLOW-2200T
+		1f47 0005  FLEXFLOW-2200T 2*100GE Ethernet Adapter
 		1f47 0006  Ethernet 10G 2P FLEXFLOW-2200T
 		1f47 0007  Ethernet 25G 2P FLEXFLOW-2200T
 		1f47 0008  Ethernet 40G 2P FLEXFLOW-2200T
 		1f47 0009  Ethernet 100G 1P FLEXFLOW-2200T
 		1f47 000a  Ethernet 100G 2P FLEXFLOW-2200T
-	1002  FLEXFLOW-2200T Ethernet Controller [Virtual Function]
-	1003  FLEXFLOW-2200T Ethernet Controller [MGMT Function]
-	1004  FLEXFLOW-2200T DATA Offload Engine
+	1002  K2-Pro Family [FLEXFLOW-2200T Virtual Function]
+	1003  K2-Pro Family [FLEXFLOW-2200T MGMT Function]
+	1004  K2-Pro Family [FLEXFLOW-2200T DATA Offload Engine]
 	1005  CONFLUX-2200P NVMe Controller
-	1011  FLEXFLOW-2200T Ethernet Controller
-		1f47 0001  Ethernet 10G 2P FLEXFLOW-2200T
-		1f47 0002  Ethernet 25G 2P FLEXFLOW-2200T
-		1f47 0003  Ethernet 40G 2P FLEXFLOW-2200T
-		1f47 0004  Ethernet 100G 1P FLEXFLOW-2200T
-		1f47 0005  Ethernet 100G 2P FLEXFLOW-2200T
-		1f47 0006  Ethernet 10G 2P FLEXFLOW-2200T
-		1f47 0007  Ethernet 25G 2P FLEXFLOW-2200T
-		1f47 0008  Ethernet 40G 2P FLEXFLOW-2200T
-		1f47 0009  Ethernet 100G 1P FLEXFLOW-2200T
-		1f47 000a  Ethernet 100G 2P FLEXFLOW-2200T
-# RDMA-PF
-	1203  FLEXFLOW-2200T RoCEv2 Network Controller
+	1011  K3-T Family
+		1dcf 0363  K3_F2_10G_PCIE 2*10GE Ethernet Adapter
+		1f47 0001  F31TX2S 2*10GE Ethernet Adapter
+		1f47 0002  F31TX4S 4*10GE Ethernet Adapter
+		1f47 0003  F31TA2S 2*25GE Ethernet Adapter
+		1f47 0004  F31TA4S 4*25GE Ethernet Adapter
+		1f47 0005  FLEXFLOW-3100T 1*40GE Ethernet Adapter
+		1f47 0006  F31TC1S 1*100GE Ethernet Adapter
+		1f47 0007  F31TA2K 2*10GE Ethernet Adapter
+		1f47 0008  FLEXFLOW-3100T 4*10GE Ethernet Adapter
+		1f47 0009  F31TA2K 2*25GE Ethernet Adapter
+		1f47 000a  FLEXFLOW-3100T 4*25GE Ethernet Adapter
+	1012  K3-T Family [Virtual Function]
+	1013  K3-T Family [MGMT Function]
+	1105  CONFLUX-2200P NVMe Controller [Virtual Function]
 # Network Accelerating Card
 	2018  DPU Card
 # Network Accelerating Card
 	2020  DPU
+	3011  K3 Family [FLEXFLOW-3100R]
+		1f47 000a  FLEXFLOW-3100R 1*100GE Ethernet Adapter
+		1f47 000b  FLEXFLOW-3100R 2*100GE Ethernet Adapter
+		1f47 000c  FLEXFLOW-3100R 4*100GE Ethernet Adapter
+		1f47 000d  FLEXFLOW-3100R 8*100GE Ethernet Adapter
+		1f47 000e  FLEXFLOW-3100R 1*100GE Ethernet Adapter
+		1f47 000f  FLEXFLOW-3100R 2*100GE Ethernet Adapter
+		1f47 0010  FLEXFLOW-3100R 4*100GE Ethernet Adapter
+		1f47 0011  FLEXFLOW-3100R 8*100GE Ethernet Adapter
+	3012  K3 Family [FLEXFLOW-3100R Virtual Function]
+	3013  K3 Family [FLEXFLOW-3100R MGMT Function]
 	3101  FLEXFLOW-2100R Ethernet Controller
 		1f47 0001  Ethernet 10G 2P FLEXFLOW-2100R
 		1f47 0002  Ethernet 25G 2P FLEXFLOW-2100R
@@ -28569,28 +29730,25 @@
 		1f47 0006  Ethernet 25G 2P FLEXFLOW-2200R
 		1f47 0007  Ethernet 50G 2P FLEXFLOW-2200R
 		1f47 0008  Ethernet 100G 2P FLEXFLOW-2200R
-	3211  FLEXFLOW-2200R Ethernet Controller
-		1f47 0001  Ethernet 10G 2P FLEXFLOW-2200R
-		1f47 0002  Ethernet 25G 2P FLEXFLOW-2200R
-		1f47 0003  Ethernet 50G 2P FLEXFLOW-2200R
-		1f47 0004  Ethernet 100G 2P FLEXFLOW-2200R
-		1f47 0005  Ethernet 10G 2P FLEXFLOW-2200R
-		1f47 0006  Ethernet 25G 2P FLEXFLOW-2200R
-		1f47 0007  Ethernet 50G 2P FLEXFLOW-2200R
-		1f47 0008  Ethernet 100G 2P FLEXFLOW-2200R
-	4001  CONFLUX-2200E Ethernet Controller
+	4001  K2-Pro Family [CONFLUX-2200E]
 		1f47 0001  Ethernet 25G 2P CONFLUX-2200E
 		1f47 0002  Ethernet 40G 2P CONFLUX-2200E
 		1f47 0003  Ethernet 100G 1P CONFLUX-2200E
 		1f47 0004  Ethernet 100G 2P CONFLUX-2200E
-		1f47 0005  Ethernet 25G 2P CONFLUX-2200E
+		1f47 0005  CONFLUX-2200E 2*25GE Ethernet Adapter
 		1f47 0006  Ethernet 40G 2P CONFLUX-2200E
 		1f47 0007  Ethernet 100G 1P CONFLUX-2200E
-		1f47 0008  Ethernet 100G 2P CONFLUX-2200E
-	4002  CONFLUX-2200E Ethernet Controller [Virtual Function]
-	4003  CONFLUX-2200E Ethernet Controller [MGMT Function]
-	4004  CONFLUX-2200E DATA Offload Engine
-	4203  CONFLUX-2200E RoCEv2 Network Controller
+		1f47 0008  CONFLUX-2200E 2*100GE Ethernet Adapter
+	4002  K2-Pro Family [CONFLUX-2200E Virtual Function]
+	4003  K2-Pro Family [CONFLUX-2200E MGMT Function]
+	4004  K2-Pro Family [CONFLUX-2200E DATA Offload Engine]
+	4011  K3 Family [CONFLUX-3100E]
+		1f47 0001  CONFLUX-3100E 2*10GE Ethernet Adapter
+		1f47 0002  CONFLUX-3100E 4*10GE Ethernet Adapter
+		1f47 0003  CONFLUX-3100E 2*25GE Ethernet Adapter
+		1f47 0004  CONFLUX-3100E 4*25GE Ethernet Adapter
+	4012  K3 Family [CONFLUX-3100E Virtual Function]
+	4013  K3 Family [CONFLUX-3100E MGMT Function]
 	5001  CONFLUX-2200P Ethernet Controller
 		1f47 0001  Ethernet 25G 2P CONFLUX-2200P
 		1f47 0003  Ethernet 100G 2P CONFLUX-2200P
@@ -28629,9 +29787,17 @@
 	5016  CONFLUX-2200P Ethernet Controller [YDMI Function]
 		1f47 0001  CONFLUX-2200P Ethernet Controller [YDMI Function]
 		1f47 0002  CONFLUX-2200P Ethernet Controller [YDMI Function] DPU
+	6001  K2-Pro Family [CONFLUX-2200X]
+		1f47 0002  CONFLUX-2200X 2*25GE Ethernet Adapter
+		1f47 0003  CONFLUX-2200X 2*40GE Ethernet Adapter
+		1f47 0005  CONFLUX-2200X 2*100GE Ethernet Adapter
+	6002  K2-Pro Family [CONFLUX-2200X Virtual Function]
+	6003  K2-Pro Family [CONFLUX-2200X MGMT Function]
+	6004  K2-Pro Family [CONFLUX-2200X DATA Offload Engine]
+1f49  NeuReality LTD
 1f4b  Axera Semiconductor Co., Ltd
 1f52  MangoBoost Inc.
-	1008  Mango GPUBoost - RDMA
+	1008  Mango BoostX - RoCE AI
 	1020  Mango NetworkBoost - TCP
 	1022  Mango StorageBoost - NTI
 	1023  Mango StorageBoost - NTT
@@ -28662,18 +29828,49 @@
 	0100  Default ID for Titanium FPGA PCIe Interface (AXI)
 1f82  d-Matrix
 	0011  Corsair [DMX 1000 Series]
-	00f1  Jetstream [DMX F1 Transparent NIC]
+	00f1  JetStream [DMX F1 Transparent NIC]
+1f8c  Exascend,INC.
+	8008  SM8008 NVMe SSD [Px5 Series SSD]
+		1f8c 0001  PD5 Series General
+		1f8c 0002  Px5 Series General
+	8366  SM8366 NVMe SSD [PD5 Series SSD]
+		1f8c 0001  PD5 Series General
+		1f8c 0002  Px5 Series General
 1f90  Quside Technologies
 	7024  QRNG PCIe Device
 	7025  QRNG PCIe Device
 1f99  Shenzhen Techwinsemi Technology Co., Ltd.
-	1202  TWSC TE3420 series
+	1202  TE3420 series / Patriot P320 M.2 NVMe SSD (DRAM-less)
+	1602  PCIe Gen4 x4 M.2 2280 (DRAM-less)
 	1608  PCIe Gen4 x4 M.2 2280
 	1f88  TE3420 PCIe Gen3 x4 M.2 2280
+	2269  XE4403 Series NVMe PCIe Gen4x4 SSD
+	3101  EP1021 Series M.2 2242 NVMe PCIe Gen3x4 SSD
+	3105  EP2021 Series M.2 2242 NVMe PCIe Gen4x4 SSD
+	3201  EP1021 Series M.2 2280 NVMe PCIe Gen3x4 SSD
+	3202  EP1031 Series M.2 2280 NVMe PCIe Gen3x4 SSD
+	3205  EP2021 Series M.2 2280 NVMe PCIe Gen4x4 SSD
+	3206  EP2031 Series M.2 2280 NVMe PCIe Gen4x4 SSD
+	3261  DP1421 Series M.2 2280 NVMe PCIe Gen3x4 SSD
 	3420  PCIe Gen3 x4 M.2 2280
+	6100  TE3420 Series NVMe PCIe Gen3x4 SSD
+	6101  XE3420 Series NVMe PCIe Gen3x4 SSD
+	6102  TE4407 Series NVMe PCIe Gen4x4 SSD
+	6103  XE4407 Series NVMe PCIe Gen4x4 SSD
+	6104  TE4408 Series NVMe PCIe Gen4x4 SSD
+	6105  XE4408 Series NVMe PCIe Gen4x4 SSD
+	6106  TE4402 Series NVMe PCIe Gen4x4 SSD
+	6107  XE4402 Series NVMe PCIe Gen4x4 SSD
+	6108  TE4405 Series NVMe PCIe Gen4x4 SSD
+	6109  XE4405 Series NVMe PCIe Gen4x4 SSD
+	610a  TE4406 Series NVMe PCIe Gen4x4 SSD
+	610b  XE4406 Series NVMe PCIe Gen4x4 SSD
+	610c  TE3410 Series NVMe PCIe Gen3x4 SSD
 1f9d  Axelera AI
+	0001  Europa AIPU
 	1100  Metis AIPU (rev 02)
 	11aa  Metis AIPU (rev 01)
+1fa4  Shandong SinoChip Semiconductors Co., Ltd
 1faa  Hexaflake (Shanghai) Information Technology Co., Ltd.
 	0c10  Compass C10 PF
 	0c11  Compass C10 VF
@@ -28714,6 +29911,14 @@
 		1fb0 5001  NF 5001
 		1fb0 5002  NF 5002
 		1fb0 5003  NF5003
+1fbd  Shenzhen Enrigin Technology Co., Ltd.
+	0001  D10
+	0002  D20 Plus
+	0003  D20 Max
+	0004  D20 Pro
+	0005  D20 Plus N
+	0006  D20 Pro N
+	0101  T1
 # nee Tumsan Oy
 1fc0  Ascom (Finland) Oy
 	0300  E2200 Dual E1/Rawpipe Card
@@ -28722,6 +29927,54 @@
 1fc1  QLogic, Corp.
 	000d  IBA6110 InfiniBand HCA
 	0010  IBA6120 InfiniBand HCA
+# formerly GE Intelligent Platforms
+1fc3  Emerson
+	0004  IC695ETM001 RX3i Ethernet PCI Module
+	0005  IC695ALG600 RX3i Universal Analog Input
+	0006  IC695ALG240 RX3i Isolated Analog Input
+	0007  IC695ALG331 RX3i Isolated Analog Output
+	0008  IC695PBM300 RX3i Profibus Master
+	0009  IC695PBS301 RX3i Profibus Slave
+	000a  IC695ALG616 RX3i 16 Channel Input Analog Voltage/Current
+	000b  IC695ALG708 RX3i 8 Channel Output Analog Voltage/Current
+	000c  IC695ALG626 RX3i 16 Channel Input Analog Voltage/Current with HART
+	000d  IC695ALG608 RX3i 8 Channel Input Analog Voltage/Current
+	000e  IC695ALG628 RX3i 8 Channel Input Analog Voltage/Current with HART
+	000f  IC695ALG728 RX3i 8 Channel Output Analog Voltage/Current with HART
+	0010  IC695ALG704 RX3i 4 Channel Output Analog Voltage/Current
+	0011  IC695HSC304 RX3i High Speed Counter (4 counters)
+	0012  IC695HSC308 RX3i High Speed Counter (8 counters)
+	0013  IC695PMM335 PACMotion Digital Motion Control Module
+	0014  IC695CMM002 RX3i Serial Communications Module (2 ports)
+	0015  IC695CMM004 RX3i Serial Communications Module (4 ports)
+	0016  IC695PNC001 RX3i Profinet Controller – XH4 version
+	0017  IC695PNC001 RX3i Profinet Controller – Atom-based version
+	0018  IC695CMX128 RX3i 128MB Control Memory Xchange
+	0019  IC695RMX128 RX3i 128MB Redundancy Memory Xchange
+	001a  IC695ALG106 RX3i 6 Channel Isolated Analog Input
+	001b  IC695ALG112 RX3i 12 Channel Isolated Analog Input
+	001c  IC695ALG808 RX3i 8 Channel Isolated Analog Output
+	001d  IC695ALG306 RX3i Isolated Thermocouple Module (6 Channel)
+	001e  IC695ALG312 RX3i Isolated Thermocouple Module (12 Channel)
+	001f  IC695ALG508 RX3i Isolated RTD Module (8 Channel)
+	0020  IC695ALG412 RX3i Isolated High-Speed Thermocouple Module (12 Channel)
+	0021  IC695PRS015 RX3i High-Speed Serial Pressure Transducer Module (1 Port)
+	0022  IC695MDL664 RX3i 16 Circuit Smart Input 24 VDC
+	0023  IC695MDL764 RX3i 16 Circuit Smart Output 24/125 VDC 2A (8 Positive / 8 Negative)
+	0024  IC695MDL765 RX3i 16 Circuit Smart Output 24/125 VDC 2A (16 Positive)
+	0025  IC695CNM001 RX3i CANopen Master
+# This device is not productized, and therefore does not have an IC695 catalog number.
+	0026  Advanced I/O R&D Device
+	0027  IC695ECM850 RX3i Ethernet Communication Module
+	0028  IC695RMX228 RX3i 128MB Redundancy Memory Xchange with Single Fiber transceiver
+	0029  IC695PMM345 PACMotion Digital Motion Control Module (EtherCAT)
+	002a  IC695HSC318 RX3i High Speed Counter (8 counters)
+	8003  IC695CPU310/CMU310/NIU001 RX3i Controller 300 MHz Celeron
+	8004  IC695CPU315/320/CRU320 RX3i Controller 1.0 GHz Celeron-M
+	8005  IC695PNS001/101 RX3i Profinet Scanner
+	8006  IC695CPE/CRE330 RX3i Controller 1.0 GHz G-series
+	8007  IC695CPE302/305/310/NIU001+ RX3i Controller 1.1 GHz Atom Z510
+	800d  IC695CPE302/305/310/NIU001+ RX3i Controller Atom x3930
 1fc9  Tehuti Networks Ltd.
 	3009  10-Giga TOE SmartNIC
 	3010  10-Giga TOE SmartNIC
@@ -28770,6 +30023,14 @@
 		1fc9 3015  Ethernet Adapter
 		4c52 1001  LREC6860BT 10 Gigabit Ethernet Adapter
 	4527  TN9710Q 5GBase-T/NBASE-T Ethernet Adapter
+1fcb  Varex Imaging Deutschland AG
+	0001  XRD_FG (PCGR-200) [95510214H]
+	0002  XRD_FGx Opto (PCGR-300) [95510215H]
+	0003  XRD_FGe Opto (PCGR-400 / PCGR-410) [95510216H / 95510218H]
+	0004  XRD_FGe (PCGR-210) [95510217H]
+	0005  XRD_FGe Opto V3 (PCGR-415) [95510220H]
+	0006  XRD_FGe Opto V4 (PCGR-500) [95510221H]
+	0007  XRD_FGe Opto V5 (PCGR-510) [95510222H]
 1fcc  StreamLabs
 	f416  MS416
 	fb01  MH4LM
@@ -28807,6 +30068,10 @@
 	10a1  NIC1160 Ethernet Controller Family
 		1ff2 0c11  10GE Ethernet Adapter 1160-2X
 	10a2  NIC1160 Ethernet Controller Virtual Function Family
+	10b1  NIC 1260 Ethernet Controller Family
+	10b2  NIC 1260 Ethernet Controller Virtual Function Family
+	10b3  NIC 1260C Ethernet Controller Family
+	10b4  NIC 1260C Ethernet Controller Virtual Function Family
 	20a1  IOC2110 Storage Controller
 		1ff2 0a11  2120-16i SATA3/SAS3 HBA Adapter
 		1ff2 0a12  2120-8i SATA3/SAS3 HBA Adapter
@@ -28822,19 +30087,61 @@
 		1ff2 0b23  3260-16i Tri-mode RAID Adapter
 		1ff2 0b24  3260-8i Tri-mode RAID Adapter
 1ff4  DEEPX Co., Ltd.
-	0000  DX_M1
-	0001  DX_M1A
-	1000  DX_H1
+# DX-M1, DX-M1 M.2 Module
+	0100  M1 [Series]
+# DX-H1 Card with M1
+	0101  M1 [H1]
+# DX-H1 V-NPU Card with M1
+	0102  M1 [H1 V-NPU]
+# DX-M1M, DX-M1M M.2 Module
+	0110  M1M [Series]
+# DX-H1M Card with M1M
+	0111  M1M [H1M]
+# DX-H1M V-NPU Card with M1M
+	0112  M1M [H1M V-NPU]
+# DX-H1/H1M V-NPU Card Video Processing Unit
+	2001  VPU [H1/H1M V-NPU]
 1ff8  Beijing Gengtu Technology Co.Ltd
 	2000  GT6910
 	2010  GT6908
 1ff9  Inagile Electronic Technology Co., LTD
+1fff  DENSO Corporation
+	8000  MCST PCIe controller
+	8008  MCST USB 1.1 OHCI controller
+	800a  MCST HD Audio Controller
+	800b  MCST PATA IDE Host Controller
+	800e  MCST System Power Managment Controller
+	8010  MCST PCIe 2.0 x4 Root Port
+	8011  MCST PCIe 2.0 x16 Root Port
+	8014  MCST MPV Controller
+	8017  MCST PCIe controller
+	8018  MCST I2C/SPI controller
+	8019  MCST UART controller
+	801a  MCST SATA 3 AHCI controller
+	801e  MCST USB 2.0 EHCI controller
+	8025  MCST MPV Controller
+	8026  MCST 10 Gigabit Ethernet MAC controller
+	8027  MCST Gigabit Ethernet MAC controller
+	8028  MCST I2C/SPI controller
+	8029  MCST USB 3 XHCI controller
+	802a  MCST IMG GX6650 3D GPU
+	802b  MCST Video encoder E5810
+	802c  MCST Video decoder D5520
+	802d  MCST VP9 Video encoder
+	802e  MCST VP9 Video decoder
+	802f  MCST UART controller
+	8031  MCST MGA 2.5 GPU
+	8032  MCST PCIe 3.0 x16 Root Complex
+	8033  MCST PCIe 3.0 x8 Root Complex
 2000  Smart Link Ltd.
 	2800  SmartPCI2800 V.92 PCI Soft DFT
 2001  Temporal Research Ltd
 2003  Smart Link Ltd.
 	8800  LM-I56N
 2004  Smart Link Ltd.
+201f  SpacemiT
+	0001  X60 PCIe 2.0 x2 Root Complex
+	0002  X100 PCIe Root Complex
 202c  CAEN S.p.A.
 	5818  A5818
 2036  Netforward Microelectronics Co., Ltd.
@@ -28844,10 +30151,59 @@
 		2036 0862  NF1618 Family NX862 (2*50GE)
 		2036 0863  NF1618 Family NX863 (2*100GE)
 		2036 0864  NF1618 Family NX864 (1*200GE)
+		2036 0865  NF1618 Family NX865 (2*200GE)
 	1619  NF1618 Family Virtual Function
+	8000  NP36xxx PCIe Gen 6 Switch
+		2036 0104  NP36104 PCIe Gen 6 26 port/104 lane Switch Upstream/Downstream Port
+		2036 0144  NP36144 PCIe Gen 6 36 port/144 lane Switch Upstream/Downstream Port
+		2036 1000  NP36000 PCIe Gen 6 Virtual Upstream/Downstream Port
+		2036 1001  NP36000 Virtual PCIe MGR 1.x Endpoint
+		2036 1002  NP36000 Virtual PCIe DMA 1.x Endpoint
+		2036 1003  NP36000 Virtual PCIe NTB 1.x Endpoint
+		2036 1004  NP36000 Virtual PCIe Placeholder 1.x Endpoint
+		2036 1005  NP36000 Virtual PCIe C2PMem 1.x Endpoint
+		2036 1006  NP36000 Virtual PCIe Pktgen 1.x Endpoint
 203b  XTX Markets Technologies Ltd.
+# Vendor ID 2042 assigned by PCI-SIG
+2042  Xi'an UniIC Semiconductors Co., Ltd
+# PCIe NVMe SSD
+	db00  UWSC256DDQYACC-N
+# PCIe NVMe SSD
+	db01  UWSC512DDQLBCC-N
+# PCIe NVMe SSD
+	db02  UWSC512DDQLACC-N
+# PCIe NVMe SSD
+	db03  UWSC1T0DDQLACC-N
+# PCIe NVMe SSD
+	dc00  UWSD512DDQYACA-N
+# PCIe NVMe SSD
+	dc01  UWSD1T0DDQYACA-N
+# PCIe NVMe SSD
+	dc02  UWSD2T0DDQYACA-N
+# PCIe NVMe SSD
+	dc03  UWSD1T0DDTYACA-N
+# PCIe NVMe SSD
+	dc04  UWSD2T0DDTYACA-N
+# PCIe NVMe SSD
+	dc05  UWSD4T0DDTYACA-N
+# PCIe NVMe SSD
+	dc06  UWSD512DDQYACB-N
+# PCIe NVMe SSD
+	dc07  UWSD1T0DDQYACB-N
+# PCIe NVMe SSD
+	dc08  UWSD512DDTMACA-N
+# PCIe NVMe SSD
+	dc09  UWSD1T0DDTMACA-N
+2044  Shenzhen Jiahua Zhongli Technology Co., LTD.
+	8200  CeaCent CS211X 12G SAS RAID controller
+		2044 2110  CeaCent CS2110-8i
+		2044 2111  CeaCent CS2110-16i
+	8201  CeaCent CS215X 12G SAS RAID controller
+		2044 2150  CeaCent CS2150-8i
+		2044 2151  CeaCent CS2150-16i
 2046  GXMICRO Technology (Shanghai) Co., Ltd.
 2048  Beijing SpaceControl Technology Co.Ltd
+2052  Frontgrade Gaisler AB
 2058  Lime Microsystems Ltd.
 205c  Zhejiang VMing Semiconductor Co., Ltd.
 	1514  EP9410 U.2 1.92TB NVME SSD
@@ -28855,6 +30211,22 @@
 	1534  EP9430 U.2 1.6TB NVME SSD
 	1535  EP9430 U.2 3.2TB NVME SSD
 	1536  EP9430 U.2 6.4TB NVME SSD
+205d  Shanghai Zijing Xinjie Intelligent Technology Co., Ltd.
+205e  SDTECH
+	0000  SD85xxx PCIe Gen5 Switch
+		205e 0048  SD85048 PCIe Gen 5 48 lane Switch Upstream/Downstream Port
+		205e 0096  SD85096 PCIe Gen 5 96 lane Switch Upstream/Downstream Port
+		205e 0104  SD85104 PCIe Gen 5 104 lane Switch Upstream/Downstream Port
+		205e 0105  SD85104 PCIe Gen 5 104 lane Switch Upstream/Downstream Port
+		205e 0144  SD85144 PCIe Gen 5 144 lane Switch Upstream/Downstream Port
+		205e 2004  SD85000 PCIe NT Endpoint
+		205e 2005  SD85000 PCIe gDMA Endpoint
+		205e 2006  SD85000 PCIe Management Endpoint
+	5048  SD85048 PCIe Gen 5 48 lane Switch Upstream/Downstream Port
+	5096  SD85096 PCIe Gen 5 96 lane Switch Upstream/Downstream Port
+	5104  SD85104 PCIe Gen 5 104 lane Switch Upstream/Downstream Port
+	5105  SD85104 PCIe Gen 5 104 lane Switch Upstream/Downstream Port
+	5144  SD85144 PCIe Gen 5 144 lane Switch Upstream/Downstream Port
 2061  Unis Flash Memory
 	4000  E4000 controller
 	4100  E4100 controller
@@ -28885,23 +30257,67 @@
 		2061 2061  E520Q NVMe SSD 30.72TB PCIe 5.0 U.2
 		2061 2062  E520Q NVMe SSD 61.44TB PCIe 5.0 U.2
 		2061 2063  E520Q NVMe SSD 122.88TB PCIe 5.0 U.2
+	5300  E5300 NVMe Controller
+		2061 2085  E5300 NVMe SSD 3.2TB PCIe 5.0 U.2
+		2061 2086  E5300 NVMe SSD 3.84TB PCIe 5.0 U.2
+		2061 2087  E5300 NVMe SSD 6.4TB PCIe 5.0 U.2
+		2061 2088  E5300 NVMe SSD 7.68TB PCIe 5.0 U.2
+		2061 2089  E5300 NVMe SSD 12.8TB PCIe 5.0 U.2
+		2061 208a  E5300 NVMe SSD 15.36TB PCIe 5.0 U.2
 2063  Hubei Yangtze Mason Semiconductor Technology Co., Ltd.
+	0bb8  MC3000
+	0bb9  RC3000
+	0c1c  MC3100
+	0c1d  MC3100T
+	0c80  RC3200
+	1388  MC5000
+	1389  RC5000
 	1406  ME7000 NVMe SSD
+	1b58  MC7000
+	1b59  RC7000
+	1c20  LC7200
+	36b0  ME14000 NVMe SSD
+		2063 1000  NVMe SSD ME14000 U.2 3.2TB
+		2063 1001  NVMe SSD ME14000 U.2 3.84TB
+		2063 1002  NVMe SSD ME14000 U.2 6.4TB
+		2063 1003  NVMe SSD ME14000 U.2 7.68TB
+		2063 1004  NVMe SSD ME14000 U.2 12.8TB
+		2063 1005  NVMe SSD ME14000 U.2 15.36TB
+		2063 1006  NVMe SSD ME14000 U.2 25.6TB
+		2063 1007  NVMe SSD ME14000 U.2 30.72TB
+		2063 1008  NVMe SSD ME14000 U.2 61.44TB
+		2063 1009  NVMe SSD ME14000 U.2 122.88TB
+		2063 1010  NVMe SSD ME14000 U.2 3.2TB
+		2063 1011  NVMe SSD ME14000 U.2 3.84TB
+		2063 1012  NVMe SSD ME14000 U.2 6.4TB
+		2063 1013  NVMe SSD ME14000 U.2 7.68TB
+		2063 1014  NVMe SSD ME14000 U.2 12.8TB
+		2063 1015  NVMe SSD ME14000 U.2 15.36TB
+		2063 1016  NVMe SSD ME14000 U.2 25.6TB
+		2063 1017  NVMe SSD ME14000 U.2 30.72TB
+		2063 1018  NVMe SSD ME14000 U.2 61.44TB
+		2063 1019  NVMe SSD ME14000 U.2 122.88TB
 206d  GigaIO Networks, Inc.
+2077  OpenAI
 207d  HRDT
+	0610  2-port SATA 6 Gb/s RAID Controller
+		207d 0801  TrustRAID B260s 2-port SATA RAID Adapter
 	0612  SATA BootRAID Controller
 208a  MICIUS Laboratory
 2094  Shenzhen Wodposit Electronics Co., Ltd.
 	1281  WPBSNM8-256GTP
-	1282  WPSBNM8-512GTP
+	1282  WPBSNM8-512GTP
 	1283  WPBSNM8-1TTP
 	1284  WPBSNM8-256GMP
-	1285  WPBSNM8-512GMP
-	1286  WPBSNM8-2TMP
-	1287  WPBSNM8-1TMP
-	1661  WPBSN4M8-512GMP
-	1662  WPBSN4M8-1TMP
-	1663  WPBSN4M8-2TMP
+	1285  WPBSN4M8-512GMP
+	1286  WPBSN4M8-1TMP
+	1287  WPBSN4M8-2TMP
+	1661  WPBSNM8-512GMP
+	1662  WPBSNM8-1TMP
+	1663  WPBSNM8-2TMP
+	1664  WPBSN4M8-1TGP
+	1665  WPBSN4M8-2TGP
+	1666  WPBSN4M8-4TGP
 2096  Kaitian Information Technology Co., Ltd.
 	5401  KCP54(01) 2280 PCIe G4 x4 TLCKCP54(01) 2280 PCIe G4 x4 TLC
 	5402  KCP54(02) 2280 PCIe G4 x4 TLC
@@ -28911,12 +30327,28 @@
 209b  BitIntelligence Technology
 	1000  TCU Family - TCU-1
 	1001  TCU Family - TCU-1 Virtual Function
+	1002  TCU Family - TCU-1 PCIe Switch
 209f  Mobilint, Inc.
+20a1  Etched, Inc.
+	0001  Sohu
+20a6  XCENA, Inc.
 20a7  EEVengers Inc.
 20a8  Rayson HI-TECH(SZ) Co., Ltd.
+	1202  RS512GSSD510 PCIe 3 NVMe SSD (DRAM-less)
 20a9  LDA Technologies Ltd.
 	1008  NEOTAPX FPGA Accelerator Card
 	1104  NEOTAPX FPGA Timing Synchronization Card
+	1200  MUX Ultimate FPGA Accelerator Card
+	1201  MUX Ultimate FPGA Accelerator Card
+# Requesting adding PCI-SIG registered vendor ID. See https://pcisig.com/membership/member-companies, search Genstoraige Technology Co., Ltd.
+20b4  Genstoraige Technology Co., Ltd.
+	a20c  PT200A PCIe 5.0 NVMe SSD
+	c25c  MQ205 PCIe 5.0 NVMe SSD
+	d20c  PT200 PCIe 5.0 NVMe SSD
+	d25c  PT205 PCIe 5.0 NVMe SSD
+# PT208 PCIe 5.0 NVMe SSD Device ID
+	d28c  PT208 PCIe 5.0 NVMe SSD
+20b5  Shanghai StarFive Technology Co., Ltd.
 20ba  Hangzhou Hikstorage Technology Co., Ltd.
 	1202  NAND memory controller
 		20ba 1202  NVMe SSD V2000 (DRAM-less)
@@ -28929,12 +30361,66 @@
 		20bc 2084  Ethernet Network Adapter XS-N2084-2X for 25GbE SFP28 SFP+ Dual-port ROCEv2
 		20bc 4084  Ethernet Network Adapter XS-N4084-2X for 100GbE QSFP28/56 Dual-port
 	2001  Solid State Storage
+20c0  ExpectedIT GmbH
+20c1  Suzhou Yige Technology Co., Ltd.
+	1234  YG Testchip
 20d0  Telin Semiconductor (Wuhan) Co., Ltd.
 	2001  PACIFIC-S1 NVMe SSD
 20d2  Awide Labs LTD.
 	0200  XRaid [Extreme Performance Compression RAID Accelerator]
+20d8  EHTech (Beijing) Co. Ltd.
+	0201  TUNAN-7 1x200GbE Controller
+		20d8 0201  TUNAN-7S 1x200GbE Controller
+		20d8 0211  TUNAN-7 1x200GbE Controller
+	1201  TUNAN-7 2x100GbE Controller
+		20d8 1201  TUNAN-7S 2x100GbE Controller
+		20d8 1211  TUNAN-7 2x100GbE Controller
+	2201  TUNAN-7 2x25GbE Controller
+		20d8 2201  TUNAN-7 2x25GbE Controller
+		20d8 2211  TUNAN-7V 2x25GbE Controller
+	3201  TUNAN-7 2x200GbE Controller
+		20d8 3201  TUNAN-7 2x200GbE Controller
+	4201  TUNAN-7 1x400GbE Controller
+		20d8 4201  TUNAN-7V 1x400GbE Controller
+20dc  Sharetronic Data Technology Co., Ltd.
+	1202  M.2 2280 PCIe Gen3 x 4 Series.
+		1202 1256  M.2 2280 256GB 1202+N38A
+	5000  E5000 U.2 15mm 3.84TB NVMe SSD
+	5101  E5000 U.2 15mm 7.68TB NVMe SSD
+20e1  CECloud Computing Technology Co., Ltd.
+	7101  LS X710-E
+	7103  LS X710-M
+	7104  LS X710-P
+	7180  LS X718
+	7211  LS X721-E
+	7223  LS X722-M
+	7224  LS X722-P
+20e3  Elix Systems SA
+20e7  TOPSSD
 20f4  TRENDnet
+20f6  Shenzhen Zhishi Network Technology Co., Ltd.
+	0001  MPU H1
+20f9  Shenzhen Silicon Dynamic Networks Co., Ltd.
+2100  Shenzhen Kimviking Semiconductor Co., Ltd.
+2105  Shanghai Timar Integrated Circuit Co., LTD
+2106  ZCHL Technology Co., Ltd
+	0001  HL100 Accelerator Controller
+		2106 0001  HLC100 Accelerator Card
+# HXQ
+2108  HuiLink Technologies (Xiamen) Co., Ltd.
+# HXQ
+	2401  PCIe4.0 to USB3.2 Gen2 Host Controller
+2114  EigenQ, Inc.
+	0007  QMA Board M.2 Gen2
+	000a  QMA Board PCIe Gen2
 2116  ZyDAS Technology Corp.
+# Add Vendor id 0x2123 to pci.ids
+2123  Shanghai Warpdrive Technology Co., Ltd
+# F5950QU2T3072Y02 F5950QU2T6144Y02 F5950QU2T1228Y02
+212b  Flumeio
+# NVMe SSD
+	5951  Flumeio F5950Q
+2136  Dongguan Xincun Chengbang Technology Co., Ltd.
 21b4  Hunan Goke Microelectronics Co., Ltd
 21c3  21st Century Computer Corp.
 22b8  Flex-Logix Technologies
@@ -28955,38 +30441,40 @@
 	5008  A1000/U-SNS8154P3 x2 NVMe SSD [E8]
 	500a  DC1000B NVMe SSD [E12DC]
 	500b  DC1000M NVMe SSD [SM2270]
-	500c  OM8PCP Design-In PCIe 3 NVMe SSD (DRAM-less)
-	500d  OM3PDP3 NVMe SSD
+	500c  OM8PCP3 PCIe 3 NVMe SSD (DRAM-less)
+	500d  OM3PDP3 PCIe 3 NVMe SSD (DRAM-less)
 	500e  NV1 NVMe SSD [E13T] (DRAM-less)
 	500f  NV1 NVMe SSD [SM2263XT] (DRAM-less)
 	5010  OM8SBP NVMe PCIe SSD (DRAM-less)
 	5012  DC1500M NVMe SSD [SM2270]
 	5013  KC3000/FURY Renegade NVMe SSD [E18]
-	5014  OM8SEP4 Design-In PCIe 4 NVMe SSD (TLC) (DRAM-less)
-	5016  OM3PGP4 NVMe SSD (DRAM-less)
+	5014  OM8SEP4 PCIe 4 NVMe SSD (TLC) (DRAM-less)
+	5016  OM3PGP4 PCIe 4 NVMe SSD (DRAM-less)
 	5017  NV2 NVMe SSD [SM2267XT] (DRAM-less)
 	5018  OM8SFP4 PCIe 4 NVMe SSD (DRAM-less)
 	5019  NV2 NVMe SSD [E21T] (DRAM-less)
-# 128GB
-	501a  OM8PGP4 Design-In PCIe 4 NVMe SSD (TLC) (DRAM-less)
+	501a  OM8PGP4 PCIe 4 NVMe SSD (TLC) (DRAM-less)
 	501b  OM8PGP4 NVMe PCIe SSD (DRAM-less)
 	501c  NV2 NVMe SSD [E19T] (DRAM-less)
 	501d  NV2 NVMe SSD [TC2200] (DRAM-less)
 	501e  OM3PGP4 NVMe SSD (DRAM-less)
 	501f  FURY Renegade NVMe SSD [E18] (Heatsink)
-	5021  OM8SEP4 Design-In PCIe 4 NVMe SSD (QLC) (DRAM-less)
-	5022  OM8PGP4 Design-In PCIe 4 NVMe SSD (QLC) (DRAM-less)
+	5021  OM8SEP4 PCIe 4 NVMe SSD (QLC) (DRAM-less)
+	5022  OM8PGP4 PCIe 4 NVMe SSD (QLC) (DRAM-less)
 	5023  NV2 NVMe SSD [SM2269XT] (DRAM-less)
 	5024  DC2000B NVMe SSD [E18DC]
 	5025  NV3 NVMe SSD [TC2201] (DRAM-less)
 	5026  NV3 NVMe SSD [E21T] (DRAM-less)
 	5027  NV3 NVMe SSD [E27T] (DRAM-less)
 	5028  NV3 NVMe SSD [SM2268XT2] (DRAM-less)
+	5029  OM8SGP4 PCIe 4 NVMe SSD (TLC) (DRAM-less)
 	502a  FURY Renegade G5 NVMe SSD [SM2508]
 	502b  NV3 NVMe SSD [E29T] (DRAM-less)
 	502c  DC3000ME NVMe SSD [SC5]
 	502d  OM8TAP4 PCIe 4 NVMe SSD (QLC) (DRAM-less)
+	502f  OM3SGP4 PCIe 4 NVMe SSD (TLC)
 	5030  NV3 2230 NVMe SSD [SM2268XT2] (DRAM-less)
+	5034  NV3 NVMe SSD [E33T] (DRAM-less)
 270b  Xantel Corporation
 270f  Chaintech Computer Co. Ltd
 2711  AVID Technology Inc.
@@ -28997,6 +30485,7 @@
 2a18  Video Transcode Controller
 	2a22  Video Transcode Controller
 2bd8  ROPEX Industrie-Elektronik GmbH
+2ff1  Maginfra Co., LTD
 3000  Hansol Electronics Inc.
 30c9  Luxvisions Innovation Technology Ltd.
 3100  Dynabook Inc.
@@ -29057,7 +30546,7 @@
 	1140  VR-12-PCI 12-ch Relay Actuator Card
 	1141  PCI-485(422) Multi-port Serial Board
 	1142  PCI-CAN2
-3842  eVga.com. Corp.
+3842  EVGA Corporation
 38ef  4Links
 # Wrong ID in board programmed sub-did in place of sub-vid
 393e  Lenovo (wrong ID)
@@ -29175,12 +30664,21 @@
 	7173  CH355 PCI Quad Serial Port Controller
 434e  Cornelis Networks
 	0001  CN5000 HFI Silicon, Dual Port, BGA [discrete]
-		434e 0001  CN5000 HFI Adapter, Single Port, QSFP, x16 PCIe Gen 5, Air-Cooled
-		434e 0002  CN5000 HFI Adapter, Dual Port, QSFP-DD, x16 PCIe Gen 5, Air-Cooled
-		434e 0003  CN5000 HFI Adapter, Single Port, QSFP, x16 PCIe Gen 5, Air-Cooled, Thermally Enhanced
-		434e 0004  CN5000 HFI Adapter, Single Port, QSFP, x16 PCIe Gen 5, Conduction-Cooled
+		434e 0001  CN5000 SuperNIC, Single Port, QSFP, x16 PCIe Gen 5
+		434e 0002  CN5000 SuperNIC, Dual Port, QSFP-DD, x16 PCIe Gen 5
+		434e 0003  CN5000 SuperNIC, Single Port, QSFP, x16 PCIe Gen 5, II
+		434e 0004  CN5000 SuperNIC, Dual Port, QSFP-DD, x16 PCIe Gen 5, II
 	0002  CN6000 HFI Silicon, Dual Port, BGA [discrete]
+		434e 0001  CN6000 SuperNIC, Single Port, QSFP-DD, x16 PCIe Gen 6
 	8001  CN5000 Switch Silicon, 48 Port, BGA
+# Add CN5000 Switch
+		434e 0101  CN5000 Switch
+# Add CN5000 Director Class Switch Spine
+		434e 0103  CN5000 Director Class Switch Spine
+# Add CN5000 Director Class Switch Leaf
+		434e 0104  CN5000 Director Class Switch Leaf
+# Add CN6000 Switch
+		434e 0106  CN6000 Switch
 4444  Internext Compression Inc
 	0016  iTVC16 (CX23416) Video Decoder
 		0070 0003  WinTV PVR 250
@@ -29389,6 +30887,7 @@
 4b43  KonteX Inc.
 4c48  LUNG HWA Electronics
 4c4d  Liquid-Markets GmbH
+	9997  UberNIC
 # Dev versions of TaSR, not for production.
 	9998  TaSR
 # First versions of UberNIC, not for production.
@@ -29408,6 +30907,15 @@
 		4c53 3001  PLUSTEST card (PMC)
 	0001  PLUSTEST-MM device
 		4c53 3002  PLUSTEST-MM card (PMC)
+4c54  Lisuan Technology Co., Ltd.
+	5000  LISUAN 7G100 Series Graphics
+# LISUAN 7G100 Series Graphics
+	5001  LISUAN 7G100 Series Graphics
+	5002  LISUAN 7G100 Series Graphics
+	5003  LISUAN 7G100 Series Graphics
+	5004  LISUAN 7G100 Series Graphics
+	5005  LISUAN 7G100 Series Graphics
+	5006  LISUAN 7G100 Series Graphics
 4ca1  Seanix Technology Inc
 4d51  MediaQ Inc.
 	0200  MQ-200
@@ -29696,7 +31204,7 @@
 	1022  4 photo couple 4 relay Card
 	1025  16 photo couple 16 relay Card
 	4000  WatchDog Card
-6688  Zycoo Co., Ltd
+6688  GUANGZHOU MAXSUN INFORMATION TECHNOLOGY CO., LTD.
 	1200  CooVox TDM Analog Module
 	1400  CooVOX TDM GSM Module
 	1600  CooVOX TDM E1/T1 Module
@@ -29707,12 +31215,15 @@
 	3d02  Arise1020
 	3d03  Arise-GT-1040
 	3d04  Arise1010
+	3d05  Arise2050
 	3d06  Arise-GT-10C0t
 	3d07  Arise2030
 	3d08  Arise2020
+	3d09  Arise2020C
 	3d0e  Arise10D0
 	3d40  GLF HDMI/DP Audio
 	3d41  GLF HDMI/DP Audio
+	3d42  GLF HDMI/DP Audio
 	3d43  GLF HDMI/DP Audio
 6899  ZT Systems
 # nee Qumranet
@@ -29896,7 +31407,7 @@
 		10cf 16bf  LIFEBOOK E752
 	0155  Xeon E3-1200 v2/3rd Gen Core processor PCI Express Root Port
 		8086 2010  Server Board S1200BTS
-	0156  3rd Gen Core processor Graphics Controller
+	0156  Ivy Bridge mobile GT1 [HD Graphics]
 		1043 108d  VivoBook X202EV
 	0158  Xeon E3-1200 v2/Ivy Bridge DRAM Controller
 		1043 844d  P8 series motherboard
@@ -29910,7 +31421,7 @@
 	0162  IvyBridge GT2 [HD Graphics 4000]
 		1043 84ca  P8 series motherboard
 		1849 0162  Motherboard
-	0166  3rd Gen Core processor Graphics Controller
+	0166  Ivy Bridge mobile GT2 [HD Graphics 4000]
 		1043 1517  Zenbook Prime UX31A
 		1043 2103  N56VZ
 		10cf 16c1  LIFEBOOK E752
@@ -29919,40 +31430,65 @@
 	0172  Xeon E3-1200 v2/3rd Gen Core processor Graphics Controller
 	0176  3rd Gen Core processor Graphics Controller
 	0201  Arctic Sound
-	0284  Comet Lake PCH-LP LPC Premium Controller/eSPI Controller
+	0284  400 Series Chipset Family On-Package PCH-LP Prem-U LPC/eSPI Controller
 		1028 09be  Latitude 7410
-	02a3  Comet Lake PCH-LP SMBus Host Controller
+	0285  400 Series Chipset Family On-Package PCH-LP Mainstream/Base U LPC/eSPI Controller
+	02a0  400 Series Chipset Family On-Package P2SB
+	02a1  400 Series Chipset Family On-Package PMC
+	02a3  400 Series Chipset Family On-Package SMBus
 		1028 09be  Latitude 7410
-	02a4  Comet Lake SPI (flash) Controller
+	02a4  400 Series Chipset Family On-Package SPI (flash) Controller
 		1028 09be  Latitude 7410
-	02a6  Comet Lake North Peak
-	02b0  Comet Lake PCI Express Root Port #9
-	02b1  Comet Lake PCI Express Root Port #10
-	02b3  Comet Lake PCI Express Root Port #12
-	02b4  Comet Lake PCI Express Root Port #13
-	02b5  Comet Lake PCI Express Root Port #14
-	02b8  Comet Lake PCI Express Root Port #1
-	02bc  Comet Lake PCI Express Root Port #5
-	02bf  Comet Lake PCI Express Root Port #8
-	02c5  Comet Lake Serial IO I2C Host Controller
+	02a6  400 Series Chipset Family On-Package Trace Hub
+	02a8  400 Series Chipset Family On-Package UART #0
+	02a9  400 Series Chipset Family On-Package UART #1
+	02aa  400 Series Chipset Family On-Package SPI #0
+	02ab  400 Series Chipset Family On-Package SPI #1
+	02b0  400 Series Chipset Family On-Package PCIe Root Port #9
+	02b1  400 Series Chipset Family On-Package PCIe Root Port #10
+	02b2  400 Series Chipset Family On-Package PCIe Root Port #11
+	02b3  400 Series Chipset Family On-Package PCIe Root Port #12
+	02b4  400 Series Chipset Family On-Package PCIe Root Port #13
+	02b5  400 Series Chipset Family On-Package PCIe Root Port #14
+	02b6  400 Series Chipset Family On-Package PCIe Root Port #15
+	02b7  400 Series Chipset Family On-Package PCIe Root Port #16
+	02b8  400 Series Chipset Family On-Package PCIe Root Port #1
+	02b9  400 Series Chipset Family On-Package PCIe Root Port #2
+	02ba  400 Series Chipset Family On-Package PCIe Root Port #3
+	02bb  400 Series Chipset Family On-Package PCIe Root Port #4
+	02bc  400 Series Chipset Family On-Package PCIe Root Port #5
+	02bd  400 Series Chipset Family On-Package PCIe Root Port #6
+	02be  400 Series Chipset Family On-Package PCIe Root Port #7
+	02bf  400 Series Chipset Family On-Package PCIe Root Port #8
+	02c4  400 Series Chipset Family On-Package eMMC
+	02c5  400 Series Chipset Family On-Package I2C #4
 		1028 09be  Latitude 7410
-	02c8  Comet Lake PCH-LP cAVS
+	02c6  400 Series Chipset Family On-Package I2C #5
+	02c7  400 Series Chipset Family On-Package UART #2
+	02c8  400 Series Chipset Family On-Package HD Audio
 		1028 09be  Latitude 7410
-	02d3  Comet Lake SATA AHCI Controller
-	02d7  Comet Lake RAID Controller
-	02e0  Comet Lake Management Engine Interface
+	02d3  400 Series Chipset Family On-Package SATA Controller (AHCI)
+	02d5  400 Series Chipset Family On-Package SATA Controller (RAID 0/1/5/10) no premium
+	02d7  400 Series Chipset Family On-Package SATA Controller (RAID 0/1/5/10) premium
+	02e0  400 Series Chipset Family On-Package MEI #1
 		1028 09be  Latitude 7410
-	02e3  Comet Lake AMT SOL Redirection
-	02e8  Serial IO I2C Host Controller
+	02e1  400 Series Chipset Family On-Package MEI #2
+	02e2  400 Series Chipset Family On-Package IDE Redirection (IDER-R)
+	02e3  400 Series Chipset Family On-Package Keyboard and Text (KT) Redirection
+	02e4  400 Series Chipset Family On-Package MEI #3
+	02e5  400 Series Chipset Family On-Package MEI #4
+	02e8  400 Series Chipset Family On-Package I2C #0
 		1028 09be  Latitude 7410
-	02e9  Comet Lake Serial IO I2C Host Controller
+	02e9  400 Series Chipset Family On-Package I2C #1
 		1028 09be  Latitude 7410
-	02ea  Comet Lake PCH-LP LPSS: I2C Controller #2
-	02ed  Comet Lake PCH-LP USB 3.1 xHCI Host Controller
+	02ea  400 Series Chipset Family On-Package I2C #2
+	02eb  400 Series Chipset Family On-Package I2C #3
+	02ed  400 Series Chipset Family On-Package USB 3.2 Gen 2x1 (10 Gbs) xHCI Host Controller
 		1028 09be  Latitude 7410
-	02ef  Comet Lake PCH-LP Shared SRAM
+	02ee  400 Series Chipset Family On-Package USB 3.2 Gen 1x1 (5 Gbs) Device Controller (xDCI)
+	02ef  400 Series Chipset Family On-Package Shared SRAM
 		1028 09be  Latitude 7410
-	02f0  Comet Lake PCH-LP CNVi WiFi
+	02f0  400 Series Chipset Family On-Package CNVi WiFi
 		8086 0034  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9560 160MHz 2x2 [Jefferson Peak]
 		8086 0070  Dual Band Wi-Fi 6(802.11ax) AX201 160MHz 2x2 [Harrison Peak]
 		8086 0074  Dual Band Wi-Fi 6(802.11ax) AX201 160MHz 2x2 [Harrison Peak]
@@ -29960,10 +31496,11 @@
 		8086 0264  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9461 80MHz 1x1 [Jefferson Peak]
 		8086 02a4  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9462 80MHz 1x1 [Jefferson Peak]
 		8086 4070  Dual Band Wi-Fi 6(802.11ax) AX201 160MHz 2x2 [Harrison Peak]
-	02f5  Comet Lake PCH-LP SCS3
-	02f9  Comet Lake Thermal Subsytem
+	02f5  400 Series Chipset Family On-Package SDXC
+	02f9  400 Series Chipset Family On-Package Thermal Subsystem
 		1028 09be  Latitude 7410
-	02fc  Comet Lake Integrated Sensor Solution
+	02fb  400 Series Chipset Family On-Package SPI #2
+	02fc  400 Series Chipset Family On-Package Integrated Sensor Hub
 		1028 09be  Latitude 7410
 	0309  80303 I/O Processor PCI-to-PCI Bridge
 	030d  80312 I/O Companion Chip PCI-to-PCI Bridge
@@ -29995,6 +31532,7 @@
 	040a  Xeon E3-1200 v3 Processor Integrated Graphics Controller
 	0412  Xeon E3-1200 v3/4th Gen Core Processor Integrated Graphics Controller
 		1028 05d7  Alienware X51 R2
+		103c 18e7  ProDesk 600 G1
 		103c 1998  EliteDesk 800 G1
 		17aa 3098  ThinkCentre E73
 		17aa 309f  ThinkCentre M83
@@ -30050,45 +31588,74 @@
 	0684  H470 Chipset LPC/eSPI Controller
 	0685  Z490 Chipset LPC/eSPI Controller
 	0687  Q470 Chipset LPC/eSPI Controller
-	068d  Comet Lake LPC Controller
+	068c  QM480 Chipset LPC/eSPI Controller
+	068d  HM470 Chipset LPC/eSPI Controller
 	068e  WM490 Chipset LPC/eSPI Controller
-	06a3  Comet Lake PCH SMBus Controller
-	06a4  Comet Lake PCH SPI Controller
-	06a8  Comet Lake PCH Serial IO UART Host Controller #0
-	06a9  Comet Lake PCH Serial IO UART Host Controller #1
-	06aa  Comet Lake PCH Serial IO SPI Controller #0
-	06ab  Comet Lake PCH Serial IO SPI Controller #1
-	06ac  Comet Lake PCI Express Root Port #21
-	06b0  Comet Lake PCI Express Root Port #9
-	06b8  Comet Lake PCIe Root Port #1
-	06ba  Comet Lake PCI Express Root Port #1
-	06bb  Comet Lake PCI Express Root Port #4
-	06bd  Comet Lake PCIe Port #6
-	06be  Comet Lake PCIe Root Port #7
-	06bf  Comet Lake PCIe Port #8
-	06c0  Comet Lake PCI Express Root Port #17
-	06c8  Comet Lake PCH cAVS
-	06d2  Comet Lake SATA AHCI Controller
+	0697  W480 Chipset LPC/eSPI Controller
+	06a0  400 Series Chipset Family P2SB
+	06a1  400 Series Chipset Family PMC
+	06a3  400 Series Chipset Family SMBus
+	06a4  400 Series Chipset Family SPI (flash) Controller
+	06a6  400 Series Chipset Family Trace Hub
+	06a8  400 Series Chipset Family UART #0
+	06a9  400 Series Chipset Family UART #1
+	06aa  400 Series Chipset Family GSPI #0
+	06ab  400 Series Chipset Family GSPI #1
+	06ac  400 Series Chipset Family PCIe Root Port #21
+	06ad  400 Series Chipset Family PCIe Root Port #22
+	06ae  400 Series Chipset Family PCIe Root Port #23
+	06af  400 Series Chipset Family PCIe Root Port #24
+	06b0  400 Series Chipset Family PCIe Root Port #9
+	06b1  400 Series Chipset Family PCIe Root Port #10
+	06b2  400 Series Chipset Family PCIe Root Port #11
+	06b3  400 Series Chipset Family PCIe Root Port #12
+	06b4  400 Series Chipset Family PCIe Root Port #13
+	06b5  400 Series Chipset Family PCIe Root Port #14
+	06b6  400 Series Chipset Family PCIe Root Port #15
+	06b7  400 Series Chipset Family PCIe Root Port #16
+	06b8  400 Series Chipset Family PCIe Root Port #1
+	06b9  400 Series Chipset Family PCIe Root Port #2
+	06ba  400 Series Chipset Family PCIe Root Port #3
+	06bb  400 Series Chipset Family PCIe Root Port #4
+	06bc  400 Series Chipset Family PCIe Root Port #5
+	06bd  400 Series Chipset Family PCIe Root Port #6
+	06be  400 Series Chipset Family PCIe Root Port #7
+	06bf  400 Series Chipset Family PCIe Root Port #8
+	06c0  400 Series Chipset Family PCIe Root Port #17
+	06c1  400 Series Chipset Family PCIe Root Port #18
+	06c2  400 Series Chipset Family PCIe Root Port #19
+	06c3  400 Series Chipset Family PCIe Root Port #20
+	06c7  400 Series Chipset Family UART #2
+	06c8  400 Series Chipset Family HD Audio
+	06d2  400 Series Chipset Family SATA Controller (AHCI) (Desktop)
+	06d3  400 Series Chipset Family SATA Controller (AHCI) (Mobile)
+	06d5  400 Series Chipset Family SATA Controller (RAID 0/1/5/10) no premium (Mobile)
 	06d6  Comet Lake PCH-H RAID
-	06d7  Comet Lake PCH-H RAID
-	06e0  Comet Lake HECI Controller
-	06e3  Comet Lake Keyboard and Text (KT) Redirection
-	06e8  Comet Lake PCH Serial IO I2C Controller #0
-	06e9  Comet Lake PCH Serial IO I2C Controller #1
-	06ea  Comet Lake PCH Serial IO I2C Controller #2
-	06eb  Comet Lake PCH Serial IO I2C Controller #3
-	06ed  Comet Lake USB 3.1 xHCI Host Controller
-	06ef  Comet Lake PCH Shared SRAM
-	06f0  Comet Lake PCH CNVi WiFi
+	06d7  400 Series Chipset Family SATA Controller (RAID 0/1/5/10) premium (Mobile)
+	06de  400 Series Chipset Family SATA Controller (AHCI) Optane Caching
+	06e0  400 Series Chipset Family HECI #1
+	06e1  400 Series Chipset Family HECI #2
+	06e2  400 Series Chipset Family IDE Redirection (IDE-R)
+	06e3  400 Series Chipset Family Keyboard and Text (KT) Redirection
+	06e4  400 Series Chipset Family HECI #3
+	06e5  400 Series Chipset Family HECI #4
+	06e8  400 Series Chipset Family I2C #0
+	06e9  400 Series Chipset Family I2C #1
+	06ea  400 Series Chipset Family I2C #2
+	06eb  400 Series Chipset Family I2C #3
+	06ed  400 Series Chipset Family USB 3.2 Gen 2x1 (10 Gbs) xHCI Host Controller
+	06ef  400 Series Chipset Family Shared SRAM
+	06f0  400 Series Chipset Family CNVi Wi-Fi
 		1a56 1651  Dual Band Wi-Fi 6(802.11ax) Killer AX1650s 160MHz 2x2 [Cyclone Peak]
 		1a56 1652  Dual Band Wi-Fi 6(802.11ax) Killer AX1650i 160MHz 2x2 [Cyclone Peak]
 		8086 0034  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9560 160MHz 2x2 [Jefferson Peak]
 		8086 0074  Dual Band Wi-Fi 6(802.11ax) AX201 160MHz 2x2 [Harrison Peak]
 		8086 02a4  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9462 80MHz 1x1 [Jefferson Peak]
 		8086 42a4  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9462 80MHz 1x1 [Jefferson Peak]
-	06f9  Comet Lake PCH Thermal Controller
-	06fb  Comet Lake PCH Serial IO SPI Controller #2
-	06fc  Comet Lake PCH Integrated Sensor Solution
+	06f5  400 Series Chipset Family SCS3 SDXC
+	06f9  400 Series Chipset Family Thermal Subsystem
+	06fb  400 Series Chipset Family GSPI #2
+	06fc  400 Series Chipset Family Integrated Sensor Hub
 	0700  CE Media Processor A/V Bridge
 	0701  CE Media Processor NAND Flash Controller
 	0703  CE Media Processor Media Control Unit 1
@@ -30296,6 +31863,7 @@
 	0937  Quark SoC X1000 10/100 Ethernet MAC
 	0939  Quark SoC X1000 USB EHCI Host Controller / USB 2.0 Device
 	093a  Quark SoC X1000 USB OHCI Host Controller
+	093c  WiGig(802.11ad) wireless network connection
 	0953  PCIe Data Center SSD
 		8086 3702  DC P3700 SSD
 		8086 3703  DC P3700 SSD [2.5" SFF]
@@ -30355,12 +31923,12 @@
 	0962  80960RM (i960RM) Bridge
 	0964  80960RP (i960RP) Microprocessor/Bridge
 	0975  Optane NVME SSD H10 with Solid State Storage [Teton Glacier]
-	0998  Ice Lake IEH
-	09a2  Ice Lake Memory Map/VT-d
-	09a3  Ice Lake RAS
-	09a4  Ice Lake Mesh 2 PCIe
-	09a6  Ice Lake MSM
-	09a7  Ice Lake PMON MSM
+	0998  Xeon 6900 6700 6500 Series with P-Cores Processors IEH
+	09a2  Xeon 6900 6700 6500 Series with P-Cores Processors VT-d
+	09a3  Xeon 6900 6700 6500 Series with P-Cores Processors RAS
+	09a4  Xeon 6900 6700 6500 Series with P-Cores Processors UFI
+	09a6  Xeon 6900 6700 6500 Series with P-Cores Processors MSM
+	09a7  Xeon 6900 6700 6500 Series with P-Cores Processors PMON MSM
 	09ab  RST VMD Managed Controller
 	09ad  Optane NVME SSD H20 with Solid State Storage [Pyramid Glacier]
 	09c4  PAC with Intel Arria 10 GX FPGA
@@ -30438,6 +32006,8 @@
 		1028 1fe8  Express Flash NVMe 2.0TB HHHL AIC (P4600)
 		1028 1fe9  Express Flash NVMe 4.0TB HHHL AIC (P4600)
 	0b00  Ice Lake CBDMA [QuickData Technology]
+	0b23  Xeon 6900 6700 6500 Series with P-Cores Processors IEH
+	0b25  Data Streaming Accelerator (DSA)
 	0b26  Thunderbolt 4 Bridge [Goshen Ridge 2020]
 	0b27  Thunderbolt 4 USB Controller [Goshen Ridge 2020]
 	0b2b  PAC with Intel Stratix 10 SX FPGA [FPGA PAC D5005]
@@ -30557,6 +32127,7 @@
 	0cf8  Ethernet Controller X710 Intel(R) FPGA Programmable Acceleration Card N3000 for Networking
 		8086 0000  Ethernet Controller X710 Intel(R) FPGA Programmable Acceleration Card N3000 for Networking
 		8086 0001  Ethernet Controller X710 Intel(R) FPGA Programmable Acceleration Card N3000 for Networking
+	0cfe  In-Memory Analytics Accelerator (IAA)
 	0d00  Crystal Well DRAM Controller
 	0d01  Crystal Well PCI Express x16 Controller
 	0d03  Crystal Well Dynamic Platform and Thermal Framework Processor Participant
@@ -30569,20 +32140,31 @@
 	0d22  Crystal Well Integrated Iris Pro Graphics 5200
 	0d26  Crystal Well Integrated Graphics Controller
 	0d36  Crystal Well Integrated Graphics Controller
-	0d4c  Ethernet Connection (11) I219-LM
-	0d4d  Ethernet Connection (11) I219-V
+	0d4c  400 Series Chipset Family GbE Controller (Corporate/vPro)
+	0d4d  400 Series Chipset Family GbE Controller (Consumer)
 		8086 0d4d  Ethernet Connection (11) I219-V
-	0d4e  Ethernet Connection (10) I219-LM
-	0d4f  Ethernet Connection (10) I219-V
+	0d4e  400 Series Chipset Family On-Package GbE Controller (Corporate/vPro)
+	0d4f  400 Series Chipset Family On-Package GbE Controller (Consumer)
 	0d53  Ethernet Connection (12) I219-LM
 	0d55  Ethernet Connection (12) I219-V
 	0d58  Ethernet Controller XXV710 Intel(R) FPGA Programmable Acceleration Card N3000 for Networking
 		8086 0000  Ethernet Controller XXV710 Intel(R) FPGA Programmable Acceleration Card N3000 for Networking
 		8086 0001  Ethernet Controller XXV710 Intel(R) FPGA Programmable Acceleration Card N3000 for Networking
 	0d9f  Ethernet Controller I225-IT
+	0db0  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #0
+	0db1  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #1
+	0db2  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #2
+	0db3  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #3
+	0db4  Xeon 6900 6700 6500 Series with P-Cores Processors NTB
+	0db6  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #4
+	0db7  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #5
+	0db8  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #6
+	0db9  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #7
 	0dc5  Ethernet Connection (23) I219-LM
 		1028 0c06  Precision 3580
 	0dc6  Ethernet Connection (23) I219-V
+	0dc7  Ethernet Connection I219-LM
+	0dc8  Ethernet Connection I219-V
 	0dcd  Ethernet Connection C825-X
 	0dd2  Ethernet Network Adapter I710
 		1137 0000  I710T4LG 4x1 GbE RJ45 PCIe NIC
@@ -31130,7 +32712,7 @@
 		8086 10a6  PRO/1000 PF Quad Port Server Adapter
 	10a6  82599EB 10-Gigabit Dummy Function
 	10a7  82575EB Gigabit Network Connection
-		15d9 10a7  X10DRW-i
+		15d9 10a7  AOC-SG-i2
 		8086 10a8  82575EB Gigabit Riser Card
 	10a9  82575EB Gigabit Backplane Connection
 	10b0  82573L PRO/1000 PL Network Connection
@@ -31349,6 +32931,7 @@
 	11a5  Merrifield Serial IO PWM Controller
 	11c3  Quark SoC X1000 PCIe Root Port 0
 	11c4  Quark SoC X1000 PCIe Root Port 1
+	11df  Infrastructure Data Path Function
 	11eb  Simics NVMe Controller
 	1200  IXP1200 Network Processor
 		172a 0000  AEP SSL Accelerator
@@ -31543,6 +33126,19 @@
 	123e  82466GX (IHPC) Integrated Hot-Plug Controller (hidden mode)
 	123f  82466GX Integrated Hot-Plug Controller (IHPC)
 	1240  82752 (752) AGP Graphics Accelerator
+	1248  Ethernet Controller E835-CC for backplane
+	1249  Ethernet Controller E835-CC for QSFP
+		8086 0001  Ethernet Network Adapter E835-C-Q2
+		8086 0002  Ethernet Network Adapter E835-C-Q2 for OCP 3.0
+		8086 0003  Ethernet Network Adapter E835-CC-Q1
+		8086 0004  Ethernet Network Adapter E835-CC-Q1 for OCP 3.0
+		8086 0005  Ethernet Network Adapter E835-C-Q2
+	124a  Ethernet Controller E835-CC for SFP
+		8086 0001  Ethernet Network Adapter E835-XXV-2 for OCP 3.0
+		8086 0002  Ethernet Network Adapter E835-XXV-4
+		8086 0003  Ethernet Network Adapter E835-XXV-2
+		8086 0004  Ethernet Network Adapter E835-XXV-4 for OCP 3.0
+		8086 0008  Ethernet Network Adapter E835-XXV-2
 	124b  82380FB (MPCI2) Mobile Docking Controller
 	124c  Ethernet Connection E823-L for backplane
 	124d  Ethernet Connection E823-L for SFP
@@ -31552,6 +33148,14 @@
 	125b  Ethernet Controller I226-LM
 	125c  Ethernet Controller I226-V
 	125d  Ethernet Controller I226-IT
+	1261  Ethernet Controller E835-C for backplane
+	1262  Ethernet Controller E835-C for QSFP
+	1263  Ethernet Controller E835-C for SFP
+	1265  Ethernet Controller E835-L for backplane
+	1266  Ethernet Controller E835-L for QSFP
+	1267  Ethernet Controller E835-L for SFP
+	128c  60Cx8980 Series QAT
+	128d  60Cx8980 Series QAT – Virtual Function
 	12d1  Ethernet Controller E830-CC for backplane
 	12d2  Ethernet Controller E830-CC for QSFP
 		8086 0001  Ethernet Network Adapter E830-C-Q2
@@ -31743,6 +33347,7 @@
 		1137 00bf  Ethernet Converged Network Adapter X540-T2
 		1170 0052  Ethernet Controller 10-Gigabit X540-AT2
 		15d9 0734  AOC-STG-I2T
+		16b8 7112  Twin 10G Thunderbolt 3 PCIe 10Gb Ethernet Adapter
 		17aa 1073  ThinkServer X540-T2 AnyFabric
 		17aa 4006  Ethernet Controller 10-Gigabit X540-AT2
 		1bd4 001a  10G base-T DP ER102Ti3 Rack Adapter
@@ -31776,6 +33381,7 @@
 		17aa 1509  I210 Gigabit Network Connection
 		17aa 404d  I210 PCIe 1Gb 1-Port RJ45 LOM
 		17aa 407a  I210 PCIe 1Gb 1-Port RJ45 LOM
+		1ab6 0214  TS3 Plus Thunderbolt 3 Dock PCIe NIC
 		4c52 1051  LRES1051PT Dual-port 1Gb Ethernet Network Adapter
 		4c52 1210  LREC9204CT Single-port 1Gb Ethernet Network Adapter
 		4c52 2057  LRES2057PT Dual-port 1Gb Ethernet Network Adapter
@@ -32041,6 +33647,7 @@
 		8086 000c  Ethernet Network Adapter XXV710-DA2 for OCP 3.0
 		8086 000d  Ethernet 25G 2P XXV710 OCP
 		8086 4001  Ethernet Network Adapter XXV710-2
+	1590  Ethernet Connection E810-C
 	1591  Ethernet Controller E810-C for backplane
 		8086 bcce  Ethernet Controller E810-C for Intel(R) Open FPGA Stack
 	1592  Ethernet Controller E810-C for QSFP
@@ -32071,6 +33678,7 @@
 		1137 02ea  E810XXVDA4T 4x25/10 GbE SFP28 PCIe NIC
 		4c52 1023  LRES1023PF Quad-port 25Gb Ethernet Server Adapter
 		4c52 3027  LRES3027PF Quad-port 25Gb Ethernet Server Adapter for OCP
+		4c52 6080  LRES6080PF TimeSync 25G/10GbE Quad-Port Time Synchronization Ethernet Card
 		8086 0002  Ethernet Network Adapter E810-L-2
 		8086 0005  Ethernet Network Adapter E810-XXV-4
 		8086 0006  Ethernet Network Adapter E810-XXV-4
@@ -32078,6 +33686,7 @@
 		8086 0008  Ethernet Network Adapter E810-XXV-2
 		8086 0009  Ethernet Network Adapter E810-XXV-2 for OCP 2.0
 		8086 000a  Ethernet 25G 4P E810-XXV Adapter
+		8086 000b  Ethernet Network Adapter E810-XXV-2 for OCP 3.0
 		8086 000c  Ethernet Network Adapter E810-XXV-4 for OCP 3.0
 		8086 000d  Ethernet 25G 4P E810-XXV OCP
 		8086 000e  Ethernet Network Adapter E810-XXV-4T
@@ -32087,6 +33696,9 @@
 		8086 4010  Ethernet Network Adapter E810-XXV-4
 		8086 4013  Ethernet Network Adapter E810-XXV-4 for OCP 3.0
 		8086 401c  Ethernet Network Adapter E810-XXV-4 for OCP 3.0
+	1594  Ethernet Controller E810-C/X557-AT 10GBASE-T
+	1595  Ethernet Controller E810-C 1GbE
+	1598  Ethernet Connection E810-XXV
 	1599  Ethernet Controller E810-XXV for backplane
 		8086 0001  Ethernet 25G 2P E810-XXV-k Mezz
 	159a  Ethernet Controller E810-XXV for QSFP
@@ -32110,6 +33722,8 @@
 		8086 4002  Ethernet Network Adapter E810-XXV-2 for OCP 3.0
 		8086 4003  Ethernet Network Adapter E810-XXV-2
 		8086 4015  Ethernet Network Adapter E810-XXV-2 for OCP 3.0
+	159c  Ethernet Controller E810-XXV/X557-AT 10GBASE-T
+	159d  Ethernet Controller E810-XXV 1GbE
 	15a0  Ethernet Connection (2) I218-LM
 	15a1  Ethernet Connection (2) I218-V
 	15a2  Ethernet Connection (3) I218-LM
@@ -32201,8 +33815,8 @@
 	15f4  Ethernet Connection (15) I219-LM
 	15f5  Ethernet Connection (15) I219-V
 	15f6  I210 Gigabit Ethernet Connection
-	15f9  Ethernet Connection (14) I219-LM
-	15fa  Ethernet Connection (14) I219-V
+	15f9  500 Series Chipset Family GbE Controller (Corporate/vPro)
+	15fa  500 Series Chipset Family GbE Controller (Consumer)
 	15fb  Ethernet Connection (13) I219-LM
 	15fc  Ethernet Connection (13) I219-V
 	15ff  Ethernet Controller X710 for 10GBASE-T
@@ -32214,6 +33828,7 @@
 		1137 02c2  X710T4LG 4x10 GbE RJ45 PCIe NIC
 		1137 02d9  Ethernet Network Adapter X710-T2L OCP 3.0
 		1137 02da  Ethernet Network Adapter X710-T4L OCP 3.0
+		15d9 1c76  AOM-PTG-I2T-P
 # NIC-ETH565T-3S-2P OCP3.0 2x10G Base-T Card
 		193d 1082  NIC-ETH565T-3S-2P
 		4c52 1012  LRES1012PT Dual-port 10Gb Ethernet Network Adapter
@@ -32243,7 +33858,7 @@
 	1603  Broadwell-U Processor Thermal Subsystem
 	1604  Broadwell-U Host Bridge -OPI
 	1605  Broadwell-U PCI Express x8 Controller
-	1606  HD Graphics
+	1606  Broadwell-U GT1 [HD Graphics]
 	1607  Broadwell-U CHAPS Device
 	1608  Broadwell-U Host Bridge -OPI
 	1609  Broadwell-U x4 PCIe
@@ -32254,19 +33869,19 @@
 	160e  Broadwell-U Integrated Graphics
 	160f  Broadwell-U SoftSKU
 	1610  Broadwell-U Host Bridge - DMI
-	1612  HD Graphics 5600
+	1612  Broadwell-H GT2 [HD Graphics 5600]
 	1614  Broadwell-U Host Bridge - DMI
-	1616  HD Graphics 5500
+	1616  Broadwell-U GT2 [HD Graphics 5500]
 		103c 2216  ZBook 15u G2 Mobile Workstation
 	1618  Broadwell-U Host Bridge - DMI
 	161a  Broadwell-U Integrated Graphics
 	161b  Broadwell-U Integrated Graphics
 	161d  Broadwell-U Integrated Graphics
-	161e  HD Graphics 5300
-	1622  Iris Pro Graphics 6200
-	1626  HD Graphics 6000
-	162a  Iris Pro Graphics P6300
-	162b  Iris Graphics 6100
+	161e  Broadwell-Y GT2 [HD Graphics 5300]
+	1622  Broadwell-DT/H GT3 [Iris Pro Graphics 6200]
+	1626  Broadwell-U GT3 [HD Graphics 6000]
+	162a  Broadwell-DT GT3 [Iris Pro Graphics P6300]
+	162b  Broadwell-U GT3 [Iris Graphics 6100]
 	162d  Broadwell-U Integrated Graphics
 	162e  Broadwell-U Integrated Graphics
 	1632  Broadwell-U Integrated Graphics
@@ -32307,7 +33922,7 @@
 	18f3  Atom Processor P5xxx Series SATA Controller
 	1900  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 	1901  6th-10th Gen Core Processor PCIe Controller (x16)
-	1902  HD Graphics 510
+	1902  Skylake-S GT1 [HD Graphics 510]
 	1903  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Thermal Subsystem
 		1028 06d6  Latitude 7275 tablet
 		1028 06dc  Latitude E7470
@@ -32323,7 +33938,7 @@
 		17aa 2247  ThinkPad T570
 		17aa 382a  B51-80 Laptop
 	1905  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor PCIe Controller (x8)
-	1906  HD Graphics 510
+	1906  Skylake-U GT1 [HD Graphics 510]
 		17aa 382a  B51-80 Laptop
 	1908  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 	1909  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor PCIe Controller (x4)
@@ -32343,8 +33958,8 @@
 		17aa 2247  ThinkPad T570
 		17aa 224f  ThinkPad X1 Carbon 5th Gen
 		17aa 225d  ThinkPad T480
-	1912  HD Graphics 530
-	1916  Skylake GT2 [HD Graphics 520]
+	1912  Skylake-S GT2 [HD Graphics 530]
+	1916  Skylake-U GT2 [HD Graphics 520]
 		1028 06dc  Latitude E7470
 		1028 06f3  Latitude 3570
 		103c 8079  EliteBook 840 G3
@@ -32353,24 +33968,24 @@
 	1919  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Imaging Unit
 		1028 06d6  Latitude 7275 tablet
 		1028 06e6  Latitude 11 5175 2-in-1
-	191b  HD Graphics 530
+	191b  Skylake-H GT2 [HD Graphics 530]
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
-	191d  HD Graphics P530
-	191e  HD Graphics 515
+	191d  Skylake-DT/H GT2 [HD Graphics P530]
+	191e  Skylake-Y GT2 [HD Graphics 515]
 		1028 06d6  Latitude 7275 tablet
 		1028 06e6  Latitude 11 5175 2-in-1
 	191f  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 	1921  HD Graphics 520
 	1923  HD Graphics 535
-	1926  Iris Graphics 540
-	1927  Iris Graphics 550
+	1926  Skylake-U GT3 [Iris Graphics 540]
+	1927  Skylake-U GT3 [Iris Graphics 550]
 	192b  Iris Graphics 555
-	192d  Iris Graphics P555
+	192d  Skylake-H GT3 [Iris Graphics P555]
 	1932  Iris Pro Graphics 580
-	193a  Iris Pro Graphics P580
-	193b  Iris Pro Graphics 580
-	193d  Iris Pro Graphics P580
+	193a  Skylake-H GT4 [Iris Pro Graphics P580]
+	193b  Skylake-H GT4 [Iris Pro Graphics 580]
+	193d  Skylake-H GT4 [Iris Pro Graphics P580]
 	1960  80960RP (i960RP) Microprocessor
 		101e 0431  MegaRAID 431 RAID Controller
 		101e 0438  MegaRAID 438 Ultra2 LVD RAID Controller
@@ -32471,11 +34086,34 @@
 	1b48  82597EX 10GbE Ethernet Controller
 		8086 a01f  PRO/10GbE LR Server Adapter
 		8086 a11f  PRO/10GbE LR Server Adapter
-# Also rebranded as Montage IOH M88IO3020
-	1bcd  Emmitsburg (C740 Family) USB 3.2 Gen 1 xHCI Controller
+	1b81  C740 Series (Emmitsburg) Chipsets eSPI Controller
+	1ba2  C740 Series (Emmitsburg) Chipsets SATA0 Controller (AHCI)
+	1ba6  C740 Series (Emmitsburg) Chipsets SATA0 Controller (RAID)
+	1bad  C740 Series (Emmitsburg) Chipsets UART0
+	1bae  C740 Series (Emmitsburg) Chipsets UART1
+	1bb0  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #8
+	1bb1  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #9
+	1bb2  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #10
+	1bb3  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #11
+	1bb4  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #12
+	1bb5  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #13
+	1bb8  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #0
+	1bb9  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #1
+	1bba  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #2
+	1bbb  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #3
+	1bbc  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #4
+	1bbd  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #5
+	1bbe  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #6
+	1bbf  C740 Series (Emmitsburg) Chipsets PCI Express Root Port #7
+	1bc7  C740 Series (Emmitsburg) Chipsets Power Management Controller
+	1bc8  C740 Series (Emmitsburg) Chipsets Audio
+	1bc9  C740 Series (Emmitsburg) Chipsets SMBus
+	1bcd  C740 Series (Emmitsburg) Chipsets USB 3.2 Gen 1 xHCI Controller
 		1bd4 00a5  RS0800I5H16i
 	1bd2  Sapphire Rapids SATA AHCI Controller
+	1bd6  C740 Series (Emmitsburg) Chipsets SATA2 Controller (RAID)
 	1bf2  Sapphire Rapids SATA AHCI Controller
+	1bf6  C740 Series (Emmitsburg) Chipsets SATA1 Controller (RAID)
 	1c00  6 Series/C200 Series Chipset Family Desktop SATA Controller (IDE mode, ports 0-3)
 	1c01  6 Series/C200 Series Chipset Family Mobile SATA Controller (IDE mode, ports 0-3)
 	1c02  6 Series/C200 Series Chipset Family 6 port Desktop SATA AHCI Controller
@@ -32942,6 +34580,7 @@
 	201c  Sky Lake-E Non-Transparent Bridge Registers
 	201d  Volume Management Device NVMe RAID Controller
 	2020  Sky Lake-E DMI3 Registers
+		15d9 0917  X11DPi-N(T)
 		15d9 095d  X11SPM-TF
 	2021  Sky Lake-E CBDMA Registers
 	2024  Sky Lake-E MM/Vt-d Configuration Registers
@@ -32996,6 +34635,8 @@
 # Engineering sample GPU
 	2240  Larrabee
 	2241  Larrabee
+	2249  Knights Ferry coprocessor
+	224a  Knights Ferry coprocessor
 	2250  Xeon Phi coprocessor 5100 series
 	225c  Xeon Phi coprocessor SE10/7120 series
 	225d  Xeon Phi coprocessor 3120 series
@@ -34284,6 +35925,9 @@
 		1028 200a  Express Flash NVMe [Optane] 375GB AIC (P4800X)
 		8086 3904  NVMe Datacenter SSD [Optane] x4 AIC (P4800X)
 		8086 3905  NVMe Datacenter SSD [Optane] 15mm 2.5" U.2 (P4800X)
+	2710  Dynamic Load Balancer 2.0 (DLB)
+	2714  Dynamic Load Balancer 2.5 (DLB)
+	2715  Dynamic Load Balancer (DLB) Virtual Function
 	2723  Wi-Fi 6 AX200
 		1a56 1654  Killer Wi-Fi 6 AX1650x (AX200NGW)
 		8086 0084  Wi-Fi 6 AX200NGW
@@ -34708,25 +36352,25 @@
 		1028 01da  OptiPlex 745
 		1462 7235  P965 Neo MS-7235 mainboard
 	2821  82801HR/HO/HH (ICH8R/DO/DH) 6 port SATA Controller [AHCI mode]
-	2822  SATA Controller [RAID mode]
+	2822  SATA Controller (RAID 0/1/5/10) In-box Compatible ID (Desktop RST)
 		1028 020d  Inspiron 530
 		103c 2a6f  Asus IPIBL-LB Motherboard
 		1043 8277  P5K PRO Motherboard: 82801IR [ICH9R]
 		1462 7345  MS-7345 Motherboard: Intel 82801I/IR [ICH9/ICH9R]
-	2823  sSATA Controller [RAID Mode]
+	2823  SSATA Controller (RAID 0/1/5/10)
 	2824  82801HB (ICH8) 4 port SATA Controller [AHCI mode]
 		1043 81ec  P5B
 	2825  82801HR/HO/HH (ICH8R/DO/DH) 2 port SATA Controller [IDE mode]
 		1028 01da  OptiPlex 745
 		1462 7235  P965 Neo MS-7235 mainboard
-	2826  SATA Controller [RAID Mode]
+	2826  SATA Controller (RAID 0/1/5/10) In-box Compatible ID (Server/Desktop RST)
 		1d49 0100  Intel RSTe SATA Software RAID
 		1d49 0101  Intel RSTe SATA Software RAID
 		1d49 0102  Intel RSTe SATA Software RAID
 		1d49 0103  Intel RSTe SATA Software RAID
 		1d49 0104  Intel RSTe SATA Software RAID
 		1d49 0105  Intel RSTe SATA Software RAID
-	2827  sSATA Controller [RAID Mode]
+	2827  SSATA Controller (RAID 0/1/5/10)
 	2828  82801HM/HEM (ICH8M/ICH8M-E) SATA Controller [IDE mode]
 		1028 01f3  Inspiron 1420
 		103c 30c0  Compaq 6710b
@@ -34745,9 +36389,10 @@
 		17aa 20a7  ThinkPad T61/R61
 		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
 		e4bf cc47  CCG-RUMBA
-	282a  82801 Mobile SATA Controller [RAID mode]
+	282a  SATA Controller (RAID 0/1/5/10) In-box Compatible ID (Mobile RST)
 		1028 040b  Latitude E6510
 		e4bf 50c1  PC1-GROOVE
+	282b  C740 Series (Emmitsburg) Chipsets SATA2 Controller (RAID) Alternate ID
 	282f  tSATA Controller [RAID Mode]
 	2830  82801H (ICH8 Family) USB UHCI Controller #1
 		1025 0121  Aspire 5920G
@@ -34954,7 +36599,8 @@
 		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
 		e4bf cc47  CCG-RUMBA
 	2880  Ice Lake DDRIO Registers
-	28c0  Volume Management Device NVMe RAID Controller
+# also seen in Xeon 6900 6700 6500 Series with P-Cores Processors
+	28c0  Volume Management Device (VMD)
 		1d49 011a  Intel VROC (VMD NVMe RAID) for ThinkSystem V4 PL
 	2912  82801IH (ICH9DH) LPC Interface Controller
 	2914  82801IO (ICH9DO) LPC Interface Controller
@@ -35825,6 +37471,7 @@
 	2ffe  Xeon E7 v3/Xeon E5 v3/Core i7 System Address Decoder & Broadcast Registers
 		15d9 0821  X10DRW-i
 	3101  Killer E3100X 2.5 Gigabit Ethernet Controller
+	3102  Ethernet Controller I226-K
 	3140  Easel/Monette Hill Image Processor [Pixel Visual Core]
 	3165  Wireless 3165
 		8086 4010  Dual Band Wireless AC 3165 [Stone Peak 1x1]
@@ -35876,6 +37523,25 @@
 	31f0  Gemini Lake Host Bridge
 	3200  GD31244 PCI-X SATA HBA
 		1775 c200  C2K onboard SATA host bus adapter
+	3240  Xeon 6900 6700 6500 Series with P-Cores Processors UPI Misc
+	3241  Xeon 6900 6700 6500 Series with P-Cores Processors UPI link/Phy0
+	3242  Xeon 6900 6700 6500 Series with P-Cores Processors UPI Phy0
+	3245  Xeon 6900 6700 6500 Series with P-Cores Processors UPI
+	324a  Xeon 6900 6700 6500 Series with P-Cores Processors IMC
+	324c  Xeon 6900 6700 6500 Series with P-Cores Processors CHA Unicast Group 1
+	324d  Xeon 6900 6700 6500 Series with P-Cores Processors CHA Unicast Group 0
+	3250  Xeon 6900 6700 6500 Series with P-Cores Processors Ubox Event Control
+	3251  Xeon 6900 6700 6500 Series with P-Cores Processors Ubox Register Access Control Unit
+	3252  Xeon 6900 6700 6500 Series with P-Cores Processors Ubox Decode
+	3256  Xeon 6900 6700 6500 Series with P-Cores Processors Trace Hub
+	3258  Power Control Unit (PCU) CR0
+	3259  Power Control Unit (PCU) CR1
+	325a  Power Control Unit (PCU) CR2
+	325b  Power Control Unit (PCU) CR3
+	325c  Power Control Unit (PCU) CR4
+	325d  Power Control Unit (PCU) CR5
+	325e  Power Control Unit (PCU) CR6
+	325f  Power Control Unit (PCU) CR7
 	3310  IOP348 I/O Processor
 		1054 3030  HRA380 Hitachi RAID Adapter to PCIe
 		1054 3034  HRA381 Hitachi RAID Adapter to PCIe
@@ -35960,13 +37626,13 @@
 	344b  Ice Lake PCU Registers
 	344c  Ice Lake CHA Registers
 	344d  Ice Lake CHA Registers
-	344f  Ice Lake CHA Registers
+	344f  Xeon 6900 6700 6500 Series with P-Cores Processors CHA All 0
 	3450  Ice Lake Ubox Registers
 	3451  Ice Lake Ubox Registers
 	3452  Ice Lake Ubox Registers
 	3455  Ice Lake Ubox Registers
 	3456  Ice Lake NorthPeak
-	3457  Ice Lake CHA Registers
+	3457  Xeon 6900 6700 6500 Series with P-Cores Processors CHA All 1
 	3458  Ice Lake PCU Registers
 	3459  Ice Lake PCU Registers
 	345a  Ice Lake PCU Registers
@@ -36035,6 +37701,10 @@
 	3518  6311ESB/6321ESB PCI Express Downstream Port E3
 		15d9 9680  X7DBN Motherboard
 	3519  6310ESB PCI Express Downstream Port E3
+	352a  PCI Express Gen5 Port A
+	352b  PCI Express Gen5 Port B
+	352c  PCI Express Gen5 Port C
+	352d  PCI Express Gen5 Port D
 	3575  82830M/MG/MP Host Bridge
 		0e11 0030  Evo N600c
 		1014 021d  ThinkPad A/T/X Series
@@ -36208,15 +37878,18 @@
 	372b  Xeon C5500/C3500 Core
 	372c  Xeon C5500/C3500 Reserved
 	373f  Xeon C5500/C3500 IOxAPIC
-	37c0  C62x chipset series PCIe x16/x8 Upstream Port
-	37c2  C62x chipset series PCIe Virtual Switch Port 0
-	37c3  C62x chipset series PCIe Virtual Switch Port 1
-	37c4  C62x chipset series PCIe Virtual Switch Port 2
-	37c5  C62x chipset series PCIe Virtual Switch Port 3
-	37c8  C62x Chipset series QuickAssist Technology Physical Function 0~2
+	37b1  C620 Series Chipset Family Thermal Sensor
+	37c0  C620 Series Chipset Family PCIe Uplink (x16)
+	37c1  C620 Series Chipset Family PCIe Uplink (x8)
+	37c2  C620 Series Chipset Family Virtual Switch Port 0
+	37c3  C620 Series Chipset Family Virtual Switch Port 1
+	37c4  C620 Series Chipset Family Virtual Switch Port 2
+	37c5  C620 Series Chipset Family Virtual Switch Port 3
+	37c7  C620 Series Chipset Family Virtual Switch Port 5
+	37c8  C620 Series Chipset Family QAT
 		8086 0001  QuickAssist Adapter 8960
 		8086 0002  QuickAssist Adapter 8970
-	37c9  C62x Chipset QuickAssist Technology Virtual Function
+	37c9  C620 Series Chipset Family QAT Virtual Function
 	37cc  Ethernet Connection X722
 	37cd  Ethernet Virtual Function 700 Series
 	37ce  Ethernet Connection X722 for 10GbE backplane
@@ -36237,6 +37910,7 @@
 		1590 0216  Ethernet 1Gb 2-port 368i Adapter
 		1590 0217  Ethernet 1Gb 2-port 368FLR-MMT Adapter
 		1590 0247  Ethernet 1Gb 4-port 369i Adapter
+		15d9 37d1  X11DPi-N
 		17aa 4020  Ethernet Connection X722 for 1GbE
 		17aa 4021  Ethernet Connection X722 for 1GbE
 		17aa 4022  Ethernet Connection X722 for 1GbE
@@ -36654,6 +38328,7 @@
 	3e98  CoffeeLake-S GT2 [UHD Graphics 630]
 	3e9a  Coffee Lake-S GT2 [UHD Graphics P630]
 	3e9b  CoffeeLake-H GT2 [UHD Graphics 630]
+		106b 019c  MacBookPro16,1 (16", 2019)
 	3e9c  Coffee Lake-S GT1 [UHD Graphics 610]
 	3ea0  WhiskeyLake-U GT2 [UHD Graphics 620]
 		1028 089e  Inspiron 5482
@@ -36799,44 +38474,101 @@
 		8086 1216  WiMAX/WiFi Link 5150 ABG
 		8086 1311  WiMAX/WiFi Link 5150 AGN
 		8086 1316  WiMAX/WiFi Link 5150 ABG
-	4384  Q570 LPC/eSPI Controller
-	4385  Z590 LPC/eSPI Controller
-	4386  H570 LPC/eSPI Controller
-	4387  B560 LPC/eSPI Controller
-	4388  H510 LPC/eSPI Controller
-	4389  WM590 LPC/eSPI Controller
-	438a  QM580 LPC/eSPI Controller
-	438b  HM570 LPC/eSPI Controller
-	438c  C252 LPC/eSPI Controller
-	438d  C256 LPC/eSPI Controller
+	4384  Q570 Chipset eSPI Controller
+	4385  Z590 Chipset eSPI Controller
+	4386  H570 Chipset eSPI Controller
+	4387  B560 Chipset eSPI Controller
+	4388  H510 Chipset eSPI Controller
+	4389  WM590 Chipset eSPI Controller
+	438a  QM580 Chipset eSPI Controller
+	438b  HM570 Chipset eSPI Controller
+	438c  C252 Chipset eSPI Controller
+	438d  C256 Chipset eSPI Controller
 	438e  H310D LPC/eSPI Controller
-	438f  W580 LPC/eSPI Controller
+	438f  W580 Chipset eSPI Controller
 	4390  RM590E LPC/eSPI Controller
 	4391  R580E LPC/eSPI Controller
-	43a3  Tiger Lake-H SMBus Controller
-	43a4  Tiger Lake-H SPI Controller
-	43b0  Tiger Lake-H PCI Express Root Port #9
-	43b8  Tiger Lake-H PCIe Root Port #1
-	43ba  Tiger Lake-H PCIe Root Port #3
-	43bb  Tiger Lake-H PCIe Root Port #4
-	43bc  Tiger Lake-H PCI Express Root Port #5
-	43be  11th Gen Core Processor PCIe Root Port #7
-	43c0  Tiger Lake-H PCIe Root Port #17
-	43c7  Tiger Lake-H PCIe Root Port #24
-	43c8  Tiger Lake-H HD Audio Controller
-	43d3  Tiger Lake SATA AHCI Controller
-	43e0  Tiger Lake-H Management Engine Interface
-	43e3  Tiger Lake AMT SOL Redirection
-	43e8  Tiger Lake-H Serial IO I2C Controller #0
-	43e9  Tiger Lake-H Serial IO I2C Controller #1
-	43ed  Tiger Lake-H USB 3.2 Gen 2x1 xHCI Host Controller
-	43ef  Tiger Lake-H Shared SRAM
-	43f0  Tiger Lake PCH CNVi WiFi
+	43a0  500 Series Chipset Family P2SB
+	43a1  500 Series Chipset Family PMC
+	43a3  500 Series Chipset Family SMBus
+	43a4  500 Series Chipset Family SPI (flash) Controller
+	43a6  500 Series Chipset Family Trace Hub
+	43a7  500 Series Chipset Family UART #2
+	43a8  500 Series Chipset Family UART #0
+	43a9  500 Series Chipset Family UART #1
+	43aa  500 Series Chipset Family GSPI #0
+	43ab  500 Series Chipset Family GSPI #1
+	43ad  500 Series Chipset Family I2C #4
+	43ae  500 Series Chipset Family I2C #5
+	43b0  500 Series Chipset Family PCIe Root Port #9
+	43b1  500 Series Chipset Family PCIe Root Port #10
+	43b2  500 Series Chipset Family PCIe Root Port #11
+	43b3  500 Series Chipset Family PCIe Root Port #12
+	43b4  500 Series Chipset Family PCIe Root Port #13
+	43b5  500 Series Chipset Family PCIe Root Port #14
+	43b6  500 Series Chipset Family PCIe Root Port #15
+	43b7  500 Series Chipset Family PCIe Root Port #16
+	43b8  500 Series Chipset Family PCIe Root Port #1
+	43b9  500 Series Chipset Family PCIe Root Port #2
+	43ba  500 Series Chipset Family PCIe Root Port #3
+	43bb  500 Series Chipset Family PCIe Root Port #4
+	43bc  500 Series Chipset Family PCIe Root Port #5
+	43bd  500 Series Chipset Family PCIe Root Port #6
+	43be  500 Series Chipset Family PCIe Root Port #7
+	43bf  500 Series Chipset Family PCIe Root Port #8
+	43c0  500 Series Chipset Family PCIe Root Port #17
+	43c1  500 Series Chipset Family PCIe Root Port #18
+	43c2  500 Series Chipset Family PCIe Root Port #19
+	43c3  500 Series Chipset Family PCIe Root Port #20
+	43c4  500 Series Chipset Family PCIe Root Port #21
+	43c5  500 Series Chipset Family PCIe Root Port #22
+	43c6  500 Series Chipset Family PCIe Root Port #23
+	43c7  500 Series Chipset Family PCIe Root Port #24
+	43c8  500 Series Chipset Family HD Audio
+	43c9  500 Series Chipset Family HD Audio
+	43ca  500 Series Chipset Family HD Audio
+	43cb  500 Series Chipset Family HD Audio
+	43cc  500 Series Chipset Family HD Audio
+	43cd  500 Series Chipset Family HD Audio
+	43ce  500 Series Chipset Family HD Audio
+	43cf  500 Series Chipset Family HD Audio
+	43d0  500 Series Chipset Family Touch Host Controller (THC) #0
+	43d1  500 Series Chipset Family Touch Host Controller (THC) #1
+	43d2  500 Series Chipset Family SATA Controller (AHCI) (Server/Desktop)
+	43d3  500 Series Chipset Family SATA Controller (AHCI) (Mobile)
+	43d4  500 Series Chipset Family SATA Controller (RAID 0/1/5/10) no premium (Desktop)
+	43d5  500 Series Chipset Family SATA Controller (RAID 0/1/5/10) no premium (Mobile)
+	43d6  500 Series Chipset Family SATA Controller (RAID 0/1/5/10) premium (Server/Desktop)
+	43d7  500 Series Chipset Family SATA Controller (RAID 0/1/5/10) premium (Mobile)
+	43d8  500 Series Chipset Family I2C #6
+	43da  500 Series Chipset Family UART #3
+	43e0  500 Series Chipset Family CSME HECI #1
+	43e1  500 Series Chipset Family CSME HECI #2
+	43e2  500 Series Chipset Family CSME IDE Redirection (IDE-R)
+	43e3  500 Series Chipset Family CSME Keyboard and Text (KT) Redirection
+	43e4  500 Series Chipset Family CSME HECI #3
+	43e5  500 Series Chipset Family CSME HECI #4
+	43e8  500 Series Chipset Family I2C #0
+	43e9  500 Series Chipset Family I2C #1
+	43ea  500 Series Chipset Family I2C #2
+	43eb  500 Series Chipset Family I2C #3
+	43ed  500 Series Chipset Family USB 3.2 Gen 2x2 (20 Gbs) xHCI Host Controller
+	43ee  500 Series Chipset Family USB 3.2 Gen 1x1 (5 Gbs) Device Controller (xDCI)
+	43ef  500 Series Chipset Family Shared SRAM
+	43f0  500 Series Chipset Family CNVi Wi-Fi
 		8086 0034  Wireless-AC 9560
 		8086 0074  Wi-Fi 6 AX201 160MHz
 		8086 0264  Wireless-AC 9461
 		8086 02a4  Wireless-AC 9462
-	43fc  Tiger Lake-H Integrated Sensor Hub
+	43f1  500 Series Chipset Family CNVi Wi-Fi
+	43f2  500 Series Chipset Family CNVi Wi-Fi
+	43f3  500 Series Chipset Family CNVi Wi-Fi
+	43f5  500 Series Chipset Family CNVi Bluetooth
+	43f6  500 Series Chipset Family CNVi Bluetooth
+	43f7  500 Series Chipset Family CNVi Bluetooth
+	43fb  500 Series Chipset Family GSPI #2
+	43fc  500 Series Chipset Family Integrated Sensor Hub
+	43fd  500 Series Chipset Family GSPI #3
 	444e  Turbo Memory Controller
 	4511  Elkhart Lake Gaussian and Neural Accelerator
 	4538  Elkhart Lake PCI-e Root Complex
@@ -36869,7 +38601,7 @@
 	4641  12th Gen Core Processor Host Bridge/DRAM Registers
 		1028 0b10  Precision 3571
 	464d  12th Gen Core Processor PCI Express x4 Controller #0
-	464e  Alder Lake-N Thunderbolt 4 USB Controller
+	464e  Alder Lake-N Processor USB 3.2 xHCI Controller
 	464f  12th Gen Core Processor Gaussian & Neural Accelerator
 		1028 0b10  Precision 3571
 	4650  12th Gen Core Processor Host Bridge
@@ -36881,7 +38613,7 @@
 	467d  Platform Monitoring Technology
 	467e  GNA Scoring Accelerator
 	467f  Volume Management Device NVMe RAID Controller
-	4680  AlderLake-S GT1
+	4680  Alder Lake-S GT1 [UHD Graphics 770]
 	4682  Alder Lake-S GT1 [UHD Graphics 730]
 	4688  Alder Lake-HX GT1 [UHD Graphics 770]
 	468a  Alder Lake-S [UHD Graphics]
@@ -36924,6 +38656,8 @@
 	4945  402xx Series QAT Virtual Function
 	4946  420xx Series QAT
 	4947  420xx Series QAT Virtual Function
+	4948  6xxx Series QAT
+	4949  6xxx Series QAT Virtual Function
 	4b00  Elkhart Lake eSPI Controller
 	4b23  Elkhart Lake SMBus Controller
 	4b24  Elkhart Lake SPI (Flash) Controller
@@ -36938,6 +38672,8 @@
 	4b70  Elkhart Lake Management Engine Interface
 	4b7d  Elkhart Lake USB 3.10 XHCI
 	4b7f  Elkhart Lake PMC SRAM
+	4bc1  Elkhart Lake Controller Area Network (CAN) interface #0
+	4bc2  Elkhart Lake Controller Area Network (CAN) interface #1
 	4c3d  Volume Management Device NVMe RAID Controller
 	4c8a  RocketLake-S GT1 [UHD Graphics 750]
 	4c8b  RocketLake-S GT1 [UHD Graphics 730]
@@ -37168,6 +38904,15 @@
 		103c 87b9  Thunderbolt Dock G4 PCIe NIC
 		17aa 2303  ThinkPad Universal Thunderbolt 4 Dock PCIe NIC
 		1ab6 0225  TS4 On-Board 2.5GbE Ethernet Adaptor
+	5503  Ethernet Controller I226-LMvP
+	550a  Ethernet Connection (18) I219-LM
+	550b  Ethernet Connection (18) I219-LM
+	550c  800 Series Chipset Family GbE Controller (Corporate/vPro)
+	550d  800 Series Chipset Family GbE Controller (Consumer)
+	550e  Ethernet Connection (20) I219-LM
+	550f  Ethernet Connection (20) I219-V
+	5510  Ethernet Connection (21) I219-LM
+	5511  Ethernet Connection (21) I219-V
 	5690  DG2 [Arc A770M]
 	5691  DG2 [Arc A730M]
 	5692  DG2 [Arc A550M]
@@ -37183,7 +38928,11 @@
 	56a3  DG2 [Arc Xe Graphics]
 	56a4  DG2 [Arc Xe Graphics]
 	56a5  DG2 [Arc A380]
+		172f 3941  A380 ELF
+		172f 3943  A380 ELF
+		172f 4017  A380 Pioneer
 	56a6  DG2 [Arc A310]
+		172f 4019  A380 ECO
 	56a7  DG2 [Arc Xe Graphics]
 	56a8  DG2 [Arc Xe Graphics]
 	56a9  DG2 [Arc Xe Graphics]
@@ -37208,37 +38957,53 @@
 	5785  JHL9540 Thunderbolt 4 USB Controller [Barlow Ridge Host 40G 2023]
 	5786  JHL9480 Thunderbolt 5 80/120G Bridge [Barlow Ridge Hub 80G 2023]
 	5787  JHL9480 Thunderbolt 5 80/120G USB Controller [Barlow Ridge Hub 80G 2023]
-	5795  Granite Rapids Chipset LPC Controller
+	5792  Xeon 6900 6700 6500 Series with P-Cores Processors ILMI
+	5793  Xeon 6900 6700 6500 Series with P-Cores Processors ACPI
+	5794  Xeon 6900 6700 6500 Series with P-Cores Processors SPI
+	5795  Xeon 6900 6700 6500 Series with P-Cores Processors eSPI
+	5796  Xeon 6900 6700 6500 Series with P-Cores Processors SMBus
+	5797  Xeon 6900 6700 6500 Series with P-Cores Processors UART
 	579c  Ethernet Connection E825-C for backplane
 	579d  Ethernet Connection E825-C for QSFP
 	579e  Ethernet Connection E825-C for SFP
 	579f  Ethernet Connection E825-C 10GbE
+	57a0  Ethernet Connection (24) I219-LM
+	57a1  Ethernet Connection (24) I219-V
 	57a4  JHL9440 Thunderbolt 4 Bridge [Barlow Ridge Hub 40G 2023]
 	57a5  JHL9440 Thunderbolt 4 USB Controller [Barlow Ridge Hub 40G 2023]
-	57ad  E610 Virtual Function
+	57ac  Ethernet Controller E610
+	57ad  Ethernet Controller E610 Virtual Function
 	57ae  Ethernet Controller E610 Backplane
 	57af  Ethernet Controller E610 SFP
-	57b0  Ethernet Controller E610 10GBASE T
+	57b0  Ethernet Controller E610-XT/E610-XT2 10GBASE-T
 		8086 0001  Ethernet Network Adapter E610-XT4
 		8086 0002  Ethernet Network Adapter E610-XT2
 		8086 0003  Ethernet Network Adapter E610-XT4 for OCP 3.0
 		8086 0004  Ethernet Network Adapter E610-XT2 for OCP 3.0
-	57b1  Ethernet Controller E610 2.5GBASE T
+	57b1  Ethernet Controller E610-AT2 1000BASE-T
 		8086 0000  Ethernet Converged Network Adapter E610
 		8086 0002  Ethernet Network Adapter E610-IT4
 		8086 0003  Ethernet Network Adapter E610-IT4 for OCP 3.0
 	57b2  Ethernet Controller E610 SGMII
+	57b3  Ethernet Connection (25) I219-LM
+	57b4  Ethernet Connection (25) I219-V
+	57b5  Ethernet Connection (26) I219-LM
+	57b6  Ethernet Connection (26) I219-V
+	57b7  Ethernet Connection (27) I219-LM
+	57b8  Ethernet Connection (27) I219-V
+	57b9  Ethernet Connection (29) I219-LM
+	57ba  Ethernet Connection (29) I219-V
 	5845  QEMU NVM Express Controller
 		1af4 1100  QEMU Virtual Machine
 	5900  Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
 	5901  Xeon E3-1200 v6/7th Gen Core Processor PCIe Controller (x16)
-	5902  HD Graphics 610
+	5902  Kaby Lake-S GT1 [HD Graphics 610]
 	5904  Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
 		1025 115f  Aspire E5-575G
 		17aa 2247  ThinkPad T570
 		17aa 224f  ThinkPad X1 Carbon 5th Gen
 	5905  Xeon E3-1200 v6/7th Gen Core Processor PCIe Controller (x8)
-	5906  HD Graphics 610
+	5906  Kaby Lake-U GT1 [HD Graphics 610]
 	5909  Xeon E3-1200 v6/7th Gen Core Processor PCIe Controller (x4)
 	590b  HD Graphics 610
 	590c  Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
@@ -37249,31 +39014,31 @@
 		1462 7a72  H270 PC MATE
 	5910  Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
 	5911  Xeon E3-1200 v6/7th Gen Core Processor Gaussian Mixture Model
-	5912  HD Graphics 630
+	5912  Kaby Lake-S GT2 [HD Graphics 630]
 		1043 8694  H110I-PLUS Motherboard
 		1462 7994  H110M ECO/GAMING
 		1462 7a72  H270 PC MATE
 	5914  Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
 		17aa 225d  ThinkPad T480
-	5916  HD Graphics 620
+	5916  Kaby Lake-U GT2 [HD Graphics 620]
 		1025 1094  Aspire E5-575G
 		17aa 2248  ThinkPad T570
 		17aa 224f  ThinkPad X1 Carbon 5th Gen
-	5917  UHD Graphics 620
+	5917  Kaby Lake-R GT2 [UHD Graphics 620]
 		17aa 225d  ThinkPad T480 (20L5)
 		17aa 225e  ThinkPad T480
 	5918  Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
-	591b  HD Graphics 630
+	591b  Kaby Lake-H GT2 [HD Graphics 630]
 	591c  UHD Graphics 615
-	591d  HD Graphics P630
-	591e  HD Graphics 615
+	591d  Kaby Lake-DT GT2 [HD Graphics P630]
+	591e  Kaby Lake-Y GT2 [HD Graphics 615]
 	591f  Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
 	5921  HD Graphics 620
 	5923  HD Graphics 635
-	5926  Iris Plus Graphics 640
-	5927  Iris Plus Graphics 650
+	5926  Kaby Lake-U GT3 [Iris Plus Graphics 640]
+	5927  Kaby Lake-U GT3 [Iris Plus Graphics 650]
 	5a84  Apollo Lake [HD Graphics 505]
-	5a85  HD Graphics 500
+	5a85  Apollo Lake GT1 [HD Graphics 500]
 	5a88  Celeron N3350/Pentium N4200/Atom E3900 Series Imaging Unit
 	5a98  Celeron N3350/Pentium N4200/Atom E3900 Series Audio Cluster
 	5a9a  Celeron N3350/Pentium N4200/Atom E3900 Series Trusted Execution Engine
@@ -37308,12 +39073,13 @@
 	5ae8  Celeron N3350/Pentium N4200/Atom E3900 Series Low Pin Count Interface
 	5aee  Celeron N3350/Pentium N4200/Atom E3900 Series HSUART Controller #4
 	5af0  Celeron N3350/Pentium N4200/Atom E3900 Series Host Bridge
-	641d  Lunar Lake-M Dynamic Tuning Technology
+	6400  Core Ultra 200V Series Processors with 4 P-Cores 4 E-Cores Host Bridge
+	641d  Core Ultra 200V Series Processors Dynamic Tuning Technology (DTT)
 	6420  Lunar Lake [Intel Graphics]
-	643e  Lunar Lake NPU
-	645d  Lunar Lake IPU
-	647d  Lunar Lake-M Crashlog and Telemetry
-	64a0  Lunar Lake [Intel Arc Graphics 130V / 140V]
+	643e  Core Ultra 200V Series Processors NPU
+	645d  Core Ultra 200V Series Processors IPU
+	647d  Core Ultra 200V Series Processors Crash Log and Telemetry
+	64a0  Core Ultra 200V Series Processors Arc Graphics 130V/140V GPU
 	64b0  Lunar Lake [Intel Graphics]
 	65c0  5100 Chipset Memory Controller Hub
 	65e2  5100 Chipset PCI Express x4 Port 2
@@ -37335,6 +39101,24 @@
 	65f9  5100 Chipset PCI Express x8 Port 6-7
 	65fa  5100 Chipset PCI Express x16 Port 4-7
 	65ff  5100 Chipset DMA Engine
+	674c  CRI
+	674d  CRI
+	674e  CRI
+	674f  CRI
+	6750  CRI
+	6e23  Nova Lake PCH-S SMbus Controller
+	6e24  Nova Lake PCH-S SPI Controller
+	6e28  Nova Lake PCH-S Serial IO UART Controller #0
+	6e29  Nova Lake PCH-S Serial IO UART Controller #1
+	6e2a  Nova Lake PCH-S Serial IO SPI Controller #0
+	6e2b  Nova Lake PCH-S Serial IO SPI Controller #1
+	6e4c  Nova Lake PCH-S Serial IO I2C Controller #0
+	6e4d  Nova Lake PCH-S Serial IO I2C Controller #1
+	6e4e  Nova Lake PCH-S Serial IO I2C Controller #2
+	6e4f  Nova Lake PCH-S Serial IO I2C Controller #3
+	6e5e  Nova Lake PCH-S Serial IO SPI Controller #2
+	6e7a  Nova Lake PCH-S Serial IO I2C Controller #4
+	6e7b  Nova Lake PCH-S Serial IO I2C Controller #5
 	6f00  Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DMI2
 		15d9 0832  X10SRL-F
 	6f01  Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 0
@@ -37590,24 +39374,64 @@
 	71a1  440GX - 82443GX AGP bridge
 	71a2  440GX - 82443GX Host bridge (AGP disabled)
 		4c53 1000  CC7/CR7/CP7/VC7/VP7/VR7 mainboard
+	7202  Core Ultra 200H Series Processors eSPI Controller
+	7203  Core Ultra 200V Series Processors eSPI Controller
 	7360  XMM7360 LTE Advanced Modem
 	7560  XMM7560 LTE Advanced Pro Modem
 	7600  82372FB PIIX5 ISA
 	7601  82372FB PIIX5 IDE
 	7602  82372FB PIIX5 USB
 	7603  82372FB PIIX5 SMBus
-	7725  Arrow Lake-H [PCH Serial IO UART Host Controller]
-	7726  Arrow Lake-H PCH Serial IO UART Host Controller]
-	7727  Arrow Lake-H [LPC/eSPI Controller]
+	7702  Arrow Lake-H eSPI Controller
+	7720  Core Ultra 200H/200V Series Processors P2SB (SOC)
+	7721  Core Ultra 200H/200V Series Processors PMC (SOC)
+	7722  Core Ultra 200H/200V Series Processors SMBus
+	7723  Core Ultra 200H/200V Series Processors SPI (flash) Controller
+	7724  Core Ultra 200H/200V Series Processors Trace Hub
+	7725  Core Ultra 200H/200V Series Processors UART #0
+	7726  Core Ultra 200H/200V Series Processors UART #1
+	7727  Core Ultra 200H/200V Series Processors GSPI #0
+	7728  Core Ultra 200H/200V Series Processors HD Audio
 	7730  Arrow Lake-H [LPC/eSPI Controller]
-	7746  Arrow Lake-H [LPC/eSPI Controller]
-	7750  Arrow Lake-H [Serial IO I2C Host Controller]
-	7751  Arrow Lake-H [Serial IO I2C Host Controller]
-	7752  Arrow Lake-H [PCH Serial IO UART Host Controller]
-	7778  Arrow Lake-H [Serial IO I2C Host Controller]
-	7779  Arrow Lake-H [Serial IO I2C Host Controller]
-	777a  Arrow Lake-H [Serial IO I2C Host Controller]
-	777b  Arrow Lake-H [Serial IO I2C Host Controller]
+	7738  Core Ultra 200H/200V Series Processors PCIe Root Port #1
+	7739  Core Ultra 200H/200V Series Processors PCIe Root Port #2
+	773a  Core Ultra 200H/200V Series Processors PCIe Root Port #3
+	773b  Core Ultra 200H/200V Series Processors PCIe Root Port #4
+	773c  Core Ultra 200H/200V Series Processors PCIe Root Port #5
+	773d  Core Ultra 200H/200V Series Processors PCIe Root Port #6
+	773e  Core Ultra 200H/200V Series Processors PCIe Root Port #7
+	773f  Core Ultra 200H/200V Series Processors PCIe Root Port #8
+	7740  Arrow Lake CNVi WiFi
+	7745  Core Ultra 200H/200V Series Processors Integrated Sensor Hub
+	7746  Core Ultra 200H/200V Series Processors GSPI #2
+	7748  Core Ultra 200H/200V Series Processors Touch Host Controller (THC) #0 ID1
+	7749  Core Ultra 200H/200V Series Processors Touch Host Controller (THC) #0 ID2
+	774a  Core Ultra 200H/200V Series Processors Touch Host Controller (THC) #1 ID1
+	774b  Core Ultra 200H/200V Series Processors Touch Host Controller (THC) #1 ID2
+	774c  Core Ultra 200H/200V Series Processors Gaussian & Neural-Network Accelerator (GNA)
+	774d  Core Ultra 200H/200V Series Processors PCIe Root Port #9 (PXPC)
+	7750  Core Ultra 200H/200V Series Processors I2C #4
+	7751  Core Ultra 200H/200V Series Processors I2C #5
+	7752  Core Ultra 200H/200V Series Processors UART #2
+	7758  Core Ultra 200H/200V Series Processors CSME HECI #1
+	7759  Core Ultra 200H/200V Series Processors CSME HECI #2
+	775a  Core Ultra 200H/200V Series Processors CSME HECI #3
+	7763  Core Ultra 200H/200V Series Processors SATA Controller (AHCI)
+	7767  Core Ultra 200H/200V Series Processors SATA Controller (RAID 0/1/5/10) premium
+	7770  Core Ultra 200H/200V Series Processors CSME HECI #1
+	7771  Core Ultra 200H/200V Series Processors CSME HECI #2
+	7772  Core Ultra 200H/200V Series Processors CSME IDE Redirection (IDE-R)
+	7773  Core Ultra 200H/200V Series Processors CSME Keyboard and Text (KT) Redirection
+	7774  Core Ultra 200H/200V Series Processors CSME HECI #3
+	7775  Core Ultra 200H/200V Series Processors CSME HECI #4
+	7778  Core Ultra 200H/200V Series Processors I2C #0
+	7779  Core Ultra 200H/200V Series Processors I2C #1
+	777a  Core Ultra 200H/200V Series Processors I2C #2
+	777b  Core Ultra 200H/200V Series Processors I2C #3
+	777c  Core Ultra 200H/200V Series Processors I3C
+	777d  Core Ultra 200H/200V Series Processors Standalone xHCI Controller
+	777e  Core Ultra 200H/200V Series Processors Standalone USB Device Controller
+	777f  Core Ultra 200H/200V Series Processors Shared SRAM
 	7800  82740 (i740) AGP Graphics Accelerator
 		003d 0008  Starfighter AGP
 		003d 000b  Starfighter AGP
@@ -37616,72 +39440,187 @@
 		10b4 202f  Lightspeed 740
 		8086 0000  Terminator 2x/i
 		8086 0100  Intel740 Graphics Accelerator
-	7a04  Raptor Lake LPC/eSPI Controller
-	7a23  Raptor Lake-S PCH SMBus Controller
-	7a24  Raptor Lake SPI (flash) Controller
-	7a27  Raptor Lake-S PCH Shared SRAM
-	7a30  Raptor Lake PCI Express Root Port #9
-	7a38  Raptor Lake PCI Express Root Port #1
-	7a3a  Raptor Point-S PCH - PCI Express Root Port 3
-	7a3b  Raptor Lake PCI Express Root Port #4
-	7a40  Raptor Lake PCI Express Root Port #17
-	7a44  Raptor Lake PCI Express Root Port #21
-	7a48  Raptor Lake PCI Express Root Port #25
-	7a4c  Raptor Lake Serial IO I2C Host Controller #0
-	7a4d  Raptor Lake Serial IO I2C Host Controller #1
-	7a4e  Raptor Lake Serial IO I2C Host Controller #2
-	7a50  Raptor Lake High Definition Audio Controller
-	7a60  Raptor Lake USB 3.2 Gen 2x2 (20 Gb/s) XHCI Host Controller
-	7a62  Raptor Lake SATA AHCI Controller
-	7a68  Raptor Lake CSME HECI #1
-	7a69  Raptor Lake CSME HECI #2
-	7a70  Raptor Lake-S PCH CNVi WiFi
+	7a04  Z790 Chipset eSPI Controller
+	7a05  H770 Chipset eSPI Controller
+	7a06  B760 Chipset eSPI Controller
+	7a0c  HM770 Chipset eSPI Controller
+	7a0d  WM790 Chipset LPC/eSPI Controller
+	7a13  C266 Chipset eSPI Controller
+	7a14  C262 Chipset eSPI Controller
+	7a20  700 Series Chipset Family P2SB
+	7a21  700 Series Chipset Family PMC
+	7a23  700 Series Chipset Family SMBus
+	7a24  700 Series Chipset Family SPI (flash) Controller
+	7a26  700 Series Chipset Family Trace Hub
+	7a27  700 Series Chipset Family Shared SRAM
+	7a28  700 Series Chipset Family UART #0
+	7a29  700 Series Chipset Family UART #1
+	7a2a  700 Series Chipset Family GSPI #0
+	7a2b  700 Series Chipset Family GSPI #1
+	7a30  700 Series Chipset Family PCIe Root Port #9
+	7a31  700 Series Chipset Family PCIe Root Port #10
+	7a32  700 Series Chipset Family PCIe Root Port #11
+	7a33  700 Series Chipset Family PCIe Root Port #12
+	7a34  700 Series Chipset Family PCIe Root Port #13
+	7a35  700 Series Chipset Family PCIe Root Port #14
+	7a36  700 Series Chipset Family PCIe Root Port #15
+	7a37  700 Series Chipset Family PCIe Root Port #16
+	7a38  700 Series Chipset Family PCIe Root Port #1
+	7a39  700 Series Chipset Family PCIe Root Port #2
+	7a3a  700 Series Chipset Family PCIe Root Port #3
+	7a3b  700 Series Chipset Family PCIe Root Port #4
+	7a3c  700 Series Chipset Family PCIe Root Port #5
+	7a3d  700 Series Chipset Family PCIe Root Port #6
+	7a3e  700 Series Chipset Family PCIe Root Port #7
+	7a3f  700 Series Chipset Family PCIe Root Port #8
+	7a40  700 Series Chipset Family PCIe Root Port #17
+	7a41  700 Series Chipset Family PCIe Root Port #18
+	7a42  700 Series Chipset Family PCIe Root Port #19
+	7a43  700 Series Chipset Family PCIe Root Port #20
+	7a44  700 Series Chipset Family PCIe Root Port #21
+	7a45  700 Series Chipset Family PCIe Root Port #22
+	7a46  700 Series Chipset Family PCIe Root Port #23
+	7a47  700 Series Chipset Family PCIe Root Port #24
+	7a48  700 Series Chipset Family PCIe Root Port #25
+	7a49  700 Series Chipset Family PCIe Root Port #26
+	7a4a  700 Series Chipset Family PCIe Root Port #27
+	7a4b  700 Series Chipset Family PCIe Root Port #28
+	7a4c  700 Series Chipset Family I2C Controller #0
+	7a4d  700 Series Chipset Family I2C Controller #1
+	7a4e  700 Series Chipset Family I2C Controller #2
+	7a4f  700 Series Chipset Family I2C Controller #3
+	7a50  700 Series Chipset Family HD Audio
+	7a51  700 Series Chipset Family HD Audio
+	7a52  700 Series Chipset Family HD Audio
+	7a53  700 Series Chipset Family HD Audio
+	7a54  700 Series Chipset Family HD Audio
+	7a55  700 Series Chipset Family HD Audio
+	7a56  700 Series Chipset Family HD Audio
+	7a57  700 Series Chipset Family HD Audio
+	7a5c  700 Series Chipset Family UART #3
+	7a60  700 Series Chipset Family USB 3.2 Gen 2x2 (20 Gbs) xHCI Host Controller
+	7a61  700 Series Chipset Family USB 3.2 Gen 1x1 (5 Gbs) Device Controller (xDCI)
+	7a62  700 Series Chipset Family SATA Controller (AHCI)
+	7a68  700 Series Chipset Family CSME HECI #1
+	7a69  700 Series Chipset Family CSME HECI #2
+	7a6a  700 Series Chipset Family CSME IDE Redirection (IDE-R)
+	7a6b  700 Series Chipset Family CSME Keyboard and Text (KT) Redirection
+	7a6c  700 Series Chipset Family CSME HECI #3
+	7a6d  700 Series Chipset Family CSME HECI #4
+	7a70  700 Series Chipset Family CNVi Wi-Fi
+		8086 0074  Wi-Fi 6 AX201 160MHz
 		8086 0090  WiFi 6E AX211 160MHz
-# Unlike other PCH components. The eSPI controller is specific to each chipset model
-	7a84  Z690 Chipset LPC/eSPI Controller
-	7a85  LPC Controller/eSPI Controller (H670)
-	7aa3  Alder Lake-S PCH SMBus Controller
-	7aa4  Alder Lake-S PCH SPI Controller
-	7aa7  Alder Lake-S PCH Shared SRAM
-	7aa8  Alder Lake-S PCH Serial IO UART #0
-	7aab  Alder Lake-S PCH Serial IO SPI Controller #1
-	7ab0  Alder Lake-S PCH PCI Express Root Port #9
-	7ab4  Alder Lake-S PCH PCI Express Root Port #13
-	7ab8  Alder Lake-S PCH PCI Express Root Port #1
-	7ab9  Alder Lake-S PCH PCI Express Root Port #2
-	7aba  Alder Lake-S PCH PCI Express Root Port #3
-	7abc  Alder Lake-S PCH PCI Express Root Port #5
-	7abd  Alder Lake-S PCH PCI Express Root Port #6
-	7abf  Alder Lake-S PCH PCI Express Root Port #8
-	7ac4  Alder Lake-S PCH PCI Express Root Port #21
-	7ac8  Alder Lake-S PCH PCI Express Root Port #25
-	7acc  Alder Lake-S PCH Serial IO I2C Controller #0
-	7acd  Alder Lake-S PCH Serial IO I2C Controller #1
-	7ace  Alder Lake-S PCH Serial IO I2C Controller #2
-	7acf  Alder Lake-S PCH Serial IO I2C Controller #3
-	7ad0  Alder Lake-S HD Audio Controller
-	7ae0  Alder Lake-S PCH USB 3.2 Gen 2x2 XHCI Controller
-	7ae1  Alder Lake-S PCH USB 3.2 Gen 1x1 xDCI Controller
-	7ae2  Alder Lake-S PCH SATA Controller [AHCI Mode]
-	7ae8  Alder Lake-S PCH HECI Controller #1
-	7aeb  Alder Lake-S Keyboard and Text (KT) Redirection
-	7af0  Alder Lake-S PCH CNVi WiFi
+	7a71  700 Series Chipset Family CNVi Wi-Fi
+	7a72  700 Series Chipset Family CNVi Wi-Fi
+	7a73  700 Series Chipset Family CNVi Wi-Fi
+	7a78  700 Series Chipset Family Integrated Sensor Hub
+	7a79  700 Series Chipset Family GSPI #3
+	7a7b  700 Series Chipset Family GSPI #2
+	7a7c  700 Series Chipset Family I2C Controller #4
+	7a7d  700 Series Chipset Family I2C Controller #5
+	7a7e  700 Series Chipset Family UART #2
+	7a83  Q670 Chipset eSPI Controller
+	7a84  Z690 Chipset eSPI Controller
+	7a85  H670 Chipset eSPI Controller
+	7a86  B660 Chipset eSPI Controller
+	7a87  H610 Chipset eSPI Controller
+	7a88  W680 Chipset eSPI Controller
+	7a8a  W790 Chipset eSPI Controller
+	7a8c  HM670 Chipset eSPI Controller
+	7a8d  WM690 Chipset eSPI Controller
+	7aa0  600 Series Chipset Family P2SB
+	7aa1  600 Series Chipset Family PMC
+	7aa3  600 Series Chipset Family SMBus
+	7aa4  600 Series Chipset Family SPI (flash) Controller
+	7aa6  600 Series Chipset Family Trace Hub
+	7aa7  600 Series Chipset Family Shared SRAM
+	7aa8  600 Series Chipset Family UART #0
+	7aa9  600 Series Chipset Family UART #1
+	7aaa  600 Series Chipset Family GSPI #0
+	7aab  600 Series Chipset Family GSPI #1
+	7ab0  600 Series Chipset Family PCIe Root Port #9
+	7ab1  600 Series Chipset Family PCIe Root Port #10
+	7ab2  600 Series Chipset Family PCIe Root Port #11
+	7ab3  600 Series Chipset Family PCIe Root Port #12
+	7ab4  600 Series Chipset Family PCIe Root Port #13
+	7ab5  600 Series Chipset Family PCIe Root Port #14
+	7ab6  600 Series Chipset Family PCIe Root Port #15
+	7ab7  600 Series Chipset Family PCIe Root Port #16
+	7ab8  600 Series Chipset Family PCIe Root Port #1
+	7ab9  600 Series Chipset Family PCIe Root Port #2
+	7aba  600 Series Chipset Family PCIe Root Port #3
+	7abb  600 Series Chipset Family PCIe Root Port #4
+	7abc  600 Series Chipset Family PCIe Root Port #5
+	7abd  600 Series Chipset Family PCIe Root Port #6
+	7abe  600 Series Chipset Family PCIe Root Port #7
+	7abf  600 Series Chipset Family PCIe Root Port #8
+	7ac0  600 Series Chipset Family PCIe Root Port #17
+	7ac1  600 Series Chipset Family PCIe Root Port #18
+	7ac2  600 Series Chipset Family PCIe Root Port #19
+	7ac3  600 Series Chipset Family PCIe Root Port #20
+	7ac4  600 Series Chipset Family PCIe Root Port #21
+	7ac5  600 Series Chipset Family PCIe Root Port #22
+	7ac6  600 Series Chipset Family PCIe Root Port #23
+	7ac7  600 Series Chipset Family PCIe Root Port #24
+	7ac8  600 Series Chipset Family PCIe Root Port #25
+	7ac9  600 Series Chipset Family PCIe Root Port #26
+	7aca  600 Series Chipset Family PCIe Root Port #27
+	7acb  600 Series Chipset Family PCIe Root Port #28
+	7acc  600 Series Chipset Family I2C Controller #0
+	7acd  600 Series Chipset Family I2C Controller #1
+	7ace  600 Series Chipset Family I2C Controller #2
+	7acf  600 Series Chipset Family 12C Controller #3
+	7ad0  600 Series Chipset Family HD Audio
+	7ad1  600 Series Chipset Family HD Audio
+	7ad2  600 Series Chipset Family HD Audio
+	7ad3  600 Series Chipset Family HD Audio
+	7ad4  600 Series Chipset Family HD Audio
+	7ad5  600 Series Chipset Family HD Audio
+	7ad6  600 Series Chipset Family HD Audio
+	7ad7  600 Series Chipset Family HD Audio
+	7adc  600 Series Chipset Family UART #3
+	7ae0  600 Series Chipset Family USB 3.2 Gen 2x2 (20Gbs) XHCI Host Controller
+	7ae1  600 Series Chipset Family USB 3.2 Gen 1x1 (5Gbs) Device Controller (xDCI)
+	7ae2  600 Series Chipset Family SATA Controller (AHCI)
+	7ae8  600 Series Chipset Family CSME HECI #1
+	7ae9  600 Series Chipset Family CSME HECI #2
+	7aea  600 Series Chipset Family CSME IDE Redirection (IDE-R)
+	7aeb  600 Series Chipset Family CSME Keyboard and Text (KT) Redirection
+	7aec  600 Series Chipset Family CSME HECI #3
+	7aed  600 Series Chipset Family CSME HECI #4
+	7af0  600 Series Chipset Family CNVi Wi-Fi
 		8086 0034  Wireless-AC 9560
 		8086 0070  Wi-Fi 6 AX201 160MHz
 		8086 0094  Wi-Fi 6 AX201 160MHz
-	7af8  Alder Lake-S Integrated Sensor Hub
-	7afc  Alder Lake-S PCH Serial IO I2C Controller #4
-	7afd  Alder Lake-S PCH Serial IO I2C Controller #5
+	7af1  600 Series Chipset Family CNVi Wi-Fi
+	7af2  600 Series Chipset Family CNVi Wi-Fi
+	7af3  600 Series Chipset Family CNVi Wi-Fi
+	7af8  600 Series Chipset Family Integrated Sensor Hub
+	7af9  600 Series Chipset Family GSPI #3
+	7afb  600 Series Chipset Family GSPI #2
+	7afc  600 Series Chipset Family I2C Controller #4
+	7afd  600 Series Chipset Family I2C Controller #5
+	7afe  600 Series Chipset Family UART #2
 	7d01  Meteor Lake-H 6p+8e cores Host Bridge/DRAM Controller
-	7d03  Meteor Lake-P Dynamic Tuning Technology
-	7d0b  Volume Management Device NVMe RAID Controller Intel Corporation
-	7d0d  Meteor Lake-P Platform Monitoring Technology
-	7d19  Meteor Lake IPU
-	7d1d  Meteor Lake NPU
+	7d03  Core Ultra 200H/200V Series Processors Dynamic Tuning Technology (DTT)
+	7d06  Core Ultra 200H Series Processors with 6 P-Cores 8 E-Cores Host Bridge
+	7d0b  Core Ultra 200H/200V Series Processors VMD
+	7d0d  Core Ultra 200H/200V Series Processors Platform Monitoring Technology (PMT)
+	7d19  Core Ultra 200H/200V Series Processors IPU
+	7d1a  Core Ultra 200S/200S-Plus Series Processors with 8 P-Cores 16 E-Cores Host Bridge
+	7d1b  Core Ultra 200S Series Processors with 8 P-Cores 12 E-Cores Host Bridge
+	7d1c  Core Ultra 200HX/HX-Plus Series Processors with 8 P-Cores 16 E-Cores Host Bridge
+	7d1d  Core Ultra 200H/200V Series Processors NPU
+	7d29  Core Ultra 200S-Plus Series Processors with 6 P-Cores 12 E-Cores Host Bridge
+	7d2a  Core Ultra 200S Series Processors with 6 P-Cores 8 E-Cores Host Bridge
+	7d2d  Core Ultra 200HX/HX-Plus Series Processors with 8 P-Cores 12 E-Cores Host Bridge
+	7d2f  Core Ultra 200HX Series Processors with 6 P-Cores 8 E-Cores Host Bridge
+	7d30  Core Ultra 200U Series Processors with 2 P-Cores 8 E-Cores Host Bridge
+	7d35  Core Ultra 200S Series Processors with 6 P-Cores 4 E-Cores Host Bridge
 	7d40  Meteor Lake-M [Intel Graphics]
 	7d41  Arrow Lake-U [Intel Graphics]
 	7d45  Meteor Lake-P [Intel Graphics]
-	7d51  Arrow Lake-P [Intel Graphics]
+	7d51  Arrow Lake-P [Arc Pro 130T/140T]
 	7d55  Meteor Lake-P [Intel Arc Graphics]
 	7d60  Meteor Lake-M [Intel Graphics]
 	7d67  Arrow Lake-S [Intel Graphics]
@@ -37717,17 +39656,94 @@
 	7e7d  Meteor Lake-P USB 3.2 Gen 2x1 xHCI Host Controller
 	7e7e  Meteor Lake-P USB Device Controller
 	7e7f  Meteor Lake-H/U Shared SRAM
-	7ec0  Meteor Lake-P Thunderbolt 4 USB Controller
-	7ec2  Meteor Lake-P Thunderbolt 4 NHI #0
-	7ec3  Meteor Lake-P Thunderbolt 4 NHI #1
-	7ec4  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #0
-	7ec5  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #1
-	7ec6  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #2
-	7ec7  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #3
-	7eca  Meteor Lake-H/U PCIe Root Port #10
-	7ecc  Meteor Lake-H PCIe Root Port #12
-	7f70  Arrow Lake-S PCH CNVi WiFi
+	7ec0  Core Ultra 200 Series Processors USB xHCI
+	7ec1  Core Ultra 200 Series Processors USB xDCI
+	7ec2  Core Ultra 200 Series Processors Thunderbolt DMA0
+	7ec3  Core Ultra 200 Series Processors Thunderbolt DMA1
+	7ec4  Core Ultra 200 Series Processors USB Type-C Subsystem PCIe Root Port #16
+	7ec5  Core Ultra 200 Series Processors USB Type-C Subsystem PCIe Root Port #17
+	7ec6  Core Ultra 200 Series Processors USB Type-C Subsystem PCIe Root Port #18
+	7ec7  Core Ultra 200 Series Processors USB Type-C Subsystem PCIe Root Port #19
+	7ec8  Core Ultra 200 Series Processors P2SB (IOE)
+	7ec9  Core Ultra 200H/200V Series Processors IEH (IOE)
+	7eca  Core Ultra 200 Series Processors PCIe Root Port #10
+	7ecb  Core Ultra 200H/200V Series Processors PCIe Root Port #11 (PXPE)
+	7ecc  Core Ultra 200 Series Processors PCIe Root Port #12
+	7ece  Core Ultra 200 Series Processors PMC (IOE)
+	7ecf  Core Ultra 200 Series Processors Shared SRAM (IOE)
+	7f03  Q870 Chipset eSPI Controller
+	7f04  Z890 Chipset eSPI Controller
+	7f06  B860 Chipset eSPI Controller
+	7f07  H810 Chipset eSPI Controller
+	7f08  W880 Chipset eSPI Controller
+	7f0c  HM870 Chipset eSPI Controller
+	7f0d  WM880 Chipset eSPI Controller
+	7f20  800 Series Chipset Family P2SB
+	7f21  800 Series Chipset Family PMC
+	7f23  800 Series Chipset Family SMBus
+	7f24  800 Series Chipset Family SPI (flash) Controller
+	7f26  800 Series Chipset Family Trace Hub
+	7f27  800 Series Chipset Family Shared SRAM
+	7f28  800 Series Chipset Family UART #0
+	7f29  800 Series Chipset Family UART #1
+	7f2a  800 Series Chipset Family GSPI #0
+	7f2b  800 Series Chipset Family GSPI #1
+	7f30  800 Series Chipset Family PCIe Root Port #9
+	7f31  800 Series Chipset Family PCIe Root Port #10
+	7f32  800 Series Chipset Family PCIe Root Port #11
+	7f33  800 Series Chipset Family PCIe Root Port #12
+	7f34  800 Series Chipset Family PCIe Root Port #13
+	7f35  800 Series Chipset Family PCIe Root Port #14
+	7f36  800 Series Chipset Family PCIe Root Port #15
+	7f37  800 Series Chipset Family PCIe Root Port #16
+	7f38  800 Series Chipset Family PCIe Root Port #1
+	7f39  800 Series Chipset Family PCIe Root Port #2
+	7f3a  800 Series Chipset Family PCIe Root Port #3
+	7f3b  800 Series Chipset Family PCIe Root Port #4
+	7f3c  800 Series Chipset Family PCIe Root Port #5
+	7f3d  800 Series Chipset Family PCIe Root Port #6
+	7f3e  800 Series Chipset Family PCIe Root Port #7
+	7f3f  800 Series Chipset Family PCIe Root Port #8
+	7f40  800 Series Chipset Family PCIe Root Port #17
+	7f41  800 Series Chipset Family PCIe Root Port #18
+	7f42  800 Series Chipset Family PCIe Root Port #19
+	7f43  800 Series Chipset Family PCIe Root Port #20
+	7f44  800 Series Chipset Family PCIe Root Port #21
+	7f45  800 Series Chipset Family PCIe Root Port #22
+	7f46  800 Series Chipset Family PCIe Root Port #23
+	7f47  800 Series Chipset Family PCIe Root Port #24
+	7f4c  800 Series Chipset Family I2C #0
+	7f4d  800 Series Chipset Family I2C #1
+	7f4e  800 Series Chipset Family I2C #2
+	7f4f  800 Series Chipset Family I2C #3
+	7f50  800 Series Chipset Family Audio Context Engine (ACE)
+	7f58  800 Series Chipset Family Touch Host Controller (THC) #0 ID1
+	7f59  800 Series Chipset Family Touch Host Controller (THC) #0 ID2
+	7f5a  800 Series Chipset Family Touch Host Controller (THC) #1 ID1
+	7f5b  800 Series Chipset Family Touch Host Controller (THC) #1 ID2
+	7f5c  800 Series Chipset Family UART #2
+	7f5d  800 Series Chipset Family UART #3
+	7f5e  800 Series Chipset Family GSPI #2
+	7f5f  800 Series Chipset Family GSPI #3
+	7f62  800 Series Chipset Family SATA Controller (AHCI)
+	7f66  800 Series Chipset Family SATA Controller (RAID 0/1/5/10) premium
+	7f68  800 Series Chipset Family CSME HECI #1
+	7f69  800 Series Chipset Family CSME HECI #2
+	7f6a  800 Series Chipset Family IDE Redirection (IDER-R)
+	7f6b  800 Series Chipset Family Keyboard and Text (KT) Redirection
+	7f6c  800 Series Chipset Family CSME HECI #3
+	7f6d  800 Series Chipset Family CSME HECI #4
+	7f6e  800 Series Chipset Family USB 3.1 xHCI HC
+	7f6f  800 Series Chipset Family USB Device Controller (OTG) (xDCI)
+	7f70  800 Series Chipset Family CNVi Wi-Fi
 		8086 0094  WiFi 6E AX211 160MHz
+	7f78  800 Series Chipset Family Integrated Sensor Hub
+	7f79  800 Series Chipset Family I3C
+	7f7a  800 Series Chipset Family I2C #4
+	7f7b  800 Series Chipset Family I2C #5
+	7f7c  800 Series Chipset Family Silicon Security Engine HECI #1
+	7f7d  800 Series Chipset Family Silicon Security Engine HECI #2
+	7f7e  800 Series Chipset Family Silicon Security Engine HECI #3
 	8002  Trusted Execution Technology Registers
 	8003  Trusted Execution Technology Registers
 	8100  US15W/US15X SCH [Poulsbo] Host Bridge
@@ -37988,6 +40004,7 @@
 	8d00  C610/X99 series chipset 4-port SATA Controller [IDE mode]
 	8d02  C610/X99 series chipset 6-Port SATA Controller [AHCI mode]
 		15d9 0821  X10DRW-i
+		15d9 086b  X10DRS
 	8d04  C610/X99 series chipset SATA Controller [RAID mode]
 	8d06  C610/X99 series chipset SATA Controller [RAID mode]
 		17aa 1031  ThinkServer RAID 110i
@@ -37995,11 +40012,13 @@
 	8d0e  C610/X99 series chipset SATA Controller [RAID mode]
 	8d10  C610/X99 series chipset PCI Express Root Port #1
 		1028 0617  Precision T5810
+		15d9 086b  X10DRS
 	8d11  C610/X99 series chipset PCI Express Root Port #1
 	8d12  C610/X99 series chipset PCI Express Root Port #2
 		1028 0617  Precision T5810
 	8d13  C610/X99 series chipset PCI Express Root Port #2
 	8d14  C610/X99 series chipset PCI Express Root Port #3
+		15d9 086b  X10DRS
 	8d15  C610/X99 series chipset PCI Express Root Port #3
 	8d16  C610/X99 series chipset PCI Express Root Port #4
 	8d17  C610/X99 series chipset PCI Express Root Port #4
@@ -38018,29 +40037,36 @@
 		1028 0617  Precision T5810
 		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
+		15d9 086b  X10DRS
 	8d24  C610/X99 series chipset Thermal Subsystem
 		15d9 0821  X10DRW-i
+		15d9 086b  X10DRS
 	8d26  C610/X99 series chipset USB Enhanced Host Controller #1
 		1028 0617  Precision T5810
 		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
+		15d9 086b  X10DRS
 	8d2d  C610/X99 series chipset USB Enhanced Host Controller #2
 		1028 0617  Precision T5810
 		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
+		15d9 086b  X10DRS
 	8d31  C610/X99 series chipset USB xHCI Host Controller
 		1028 0617  Precision T5810
 		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
+		15d9 086b  X10DRS
 	8d33  C610/X99 series chipset LAN Controller
 	8d34  C610/X99 series chipset NAND Controller
 	8d3a  C610/X99 series chipset MEI Controller #1
 		1028 0617  Precision T5810
 		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
+		15d9 086b  X10DRS
 	8d3b  C610/X99 series chipset MEI Controller #2
 		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
+		15d9 086b  X10DRS
 	8d3c  C610/X99 series chipset IDE-r Controller
 	8d3d  C610/X99 series chipset KT Controller
 	8d40  C610/X99 series chipset LPC Controller
@@ -38051,6 +40077,7 @@
 		1028 0617  Precision T5810
 		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
+		15d9 086b  X10DRS
 	8d45  C610/X99 series chipset LPC Controller
 	8d46  C610/X99 series chipset LPC Controller
 	8d47  C610/X99 series chipset LPC Controller
@@ -38066,6 +40093,7 @@
 	8d62  C610/X99 series chipset sSATA Controller [AHCI mode]
 		1028 0617  Precision T5810
 		15d9 0821  X10DRW-i
+		15d9 086b  X10DRS
 	8d64  C610/X99 series chipset sSATA Controller [RAID mode]
 	8d66  C610/X99 series chipset sSATA Controller [RAID mode]
 	8d68  C610/X99 series chipset sSATA Controller [IDE mode]
@@ -38074,9 +40102,11 @@
 		1028 0617  Precision T5810
 		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
+		15d9 086b  X10DRS
 	8d7d  C610/X99 series chipset MS SMBus 0
 	8d7e  C610/X99 series chipset MS SMBus 1
 	8d7f  C610/X99 series chipset MS SMBus 2
+		15d9 086b  X10DRS
 	9000  IXP2000 Family Network Processor
 	9001  IXP2400 Network Processor
 	9002  IXP2300 Network Processor
@@ -38407,11 +40437,14 @@
 	9db0  Cannon Point-LP PCI Express Root Port #9
 	9db1  Cannon Point-LP PCI Express Root Port #10
 	9db2  Cannon Point-LP PCI Express Root Port #1
+	9db3  Cannon Point-LP PCI Express Root Port #12
 	9db4  Cannon Point-LP PCI Express Root Port #13
 		1028 089e  Inspiron 5482
+	9db5  Cannon Point-LP PCI Express Root Port #14
 	9db6  Cannon Point-LP PCI Express Root Port #15
 	9db8  Cannon Point-LP PCI Express Root Port #1
 	9dbc  Cannon Point-LP PCI Express Root Port #5
+	9dbd  Cannon Point-LP PCI Express Root Port #6
 	9dbe  Cannon Point-LP PCI Express Root Port #7
 	9dbf  Cannon Point PCI Express Root Port #8
 	9dc4  Cannon Point-LP SD Host Controller
@@ -38451,36 +40484,56 @@
 		1043 83ac  Eee PC 1015PX
 		144d c072  Notebook N150P
 	a013  Atom Processor D4xx/D5xx/N4xx/N5xx CHAPS counter
-	a082  Tiger Lake-LP LPC Controller
-	a0a3  Tiger Lake-LP SMBus Controller
-	a0a4  Tiger Lake-LP SPI Controller
-	a0a6  Tiger Lake-LP Trace Hub
-	a0a8  Tiger Lake-LP Serial IO UART Controller #0
-	a0a9  Tiger Lake-LP Serial IO UART Controller #1
-	a0ab  Tiger Lake-LP Serial IO SPI Controller #1
-	a0b0  Tiger Lake-LP PCI Express Root Port #9
-	a0b1  Tiger Lake-LP PCI Express Root Port #10
-	a0b3  Tiger Lake-LP PCI Express Root Port #12
-	a0bc  Tiger Lake-LP PCI Express Root Port #5
-	a0bd  Tigerlake PCH-LP PCI Express Root Port #6
-	a0be  Tiger Lake-LP PCI Express Root Port #7
-	a0bf  Tiger Lake-LP PCI Express Root Port #8
-	a0c5  Tiger Lake-LP Serial IO I2C Controller #4
-	a0c6  Tiger Lake-LP Serial IO I2C Controller #5
-	a0c8  Tiger Lake-LP Smart Sound Technology Audio Controller
-# SATA controller on Intel Tiger Lake based mobile platforms in AHCI mode. Could be found on Panasonic Let's Note CF-SV2.
-	a0d3  Tiger Lake-LP SATA Controller
-	a0e0  Tiger Lake-LP Management Engine Interface
-	a0e3  Tiger Lake-LP Active Management Technology - SOL
-	a0e8  Tiger Lake-LP Serial IO I2C Controller #0
-	a0e9  Tiger Lake-LP Serial IO I2C Controller #1
-	a0ea  Tiger Lake-LP Serial IO I2C Controller #2
-	a0eb  Tiger Lake-LP Serial IO I2C Controller #3
-	a0ed  Tiger Lake-LP USB 3.2 Gen 2x1 xHCI Host Controller
-	a0ef  Tiger Lake-LP Shared SRAM
+	a082  500 Series Chipset Family On-Package eSPI Controller
+	a0a0  500 Series Chipset Family On-Package Primary-to-Sideband Bridge (P2SB)
+	a0a1  500 Series Chipset Family On-Package Power Management Controller (PMC)
+	a0a3  500 Series Chipset Family On-Package System Management Bus (SMBus)
+	a0a4  500 Series Chipset Family On-Package SPI (flash) Controller
+	a0a6  500 Series Chipset Family On-Package Trace Hub
+	a0a8  500 Series Chipset Family On-Package UART Controller #0
+	a0a9  500 Series Chipset Family On-Package UART Controller #1
+	a0aa  500 Series Chipset Family On-Package Generic SPI (GSPI) #0
+	a0ab  500 Series Chipset Family On-Package Generic SPI (GSPI) #1
+	a0b0  500 Series Chipset Family On-Package PCI Express Root Port #9
+	a0b1  500 Series Chipset Family On-Package PCI Express Root Port #10
+	a0b2  500 Series Chipset Family On-Package PCI Express Root Port #11
+	a0b3  500 Series Chipset Family On-Package PCI Express Root Port #12
+	a0b8  500 Series Chipset Family On-Package PCI Express Root Port #1
+	a0b9  500 Series Chipset Family On-Package PCI Express Root Port #2
+	a0ba  500 Series Chipset Family On-Package PCI Express Root Port #3
+	a0bb  500 Series Chipset Family On-Package PCI Express Root Port #4
+	a0bc  500 Series Chipset Family On-Package PCI Express Root Port #5
+	a0bd  500 Series Chipset Family On-Package PCI Express Root Port #6
+	a0be  500 Series Chipset Family On-Package PCI Express Root Port #7
+	a0bf  500 Series Chipset Family On-Package PCI Express Root Port #8
+	a0c5  500 Series Chipset Family On-Package I2C Controller #4
+	a0c6  500 Series Chipset Family On-Package I2C Controller #5
+	a0c7  500 Series Chipset Family On-Package UART Controller #2
+	a0c8  500 Series Chipset Family On-Package High Definition Audio (HD Audio)
+	a0d0  500 Series Chipset Family On-Package Touch Host Controller #0
+	a0d1  500 Series Chipset Family On-Package Touch Host Controller #1
+	a0d3  500 Series Chipset Family On-Package SATA Controller (AHCI)
+	a0d5  500 Series Chipset Family On-Package SATA Controller (RAID 0/1/5/10) no premium
+	a0d7  500 Series Chipset Family On-Package SATA Controller (RAID 0/1/5/10) premium
+	a0da  500 Series Chipset Family On-Package UART Controller #3
+	a0e0  500 Series Chipset Family On-Package CSME HECI #1
+	a0e1  500 Series Chipset Family On-Package CSME HECI #2
+	a0e2  500 Series Chipset Family On-Package CSME IDE Redirection (IDE-R)
+	a0e3  500 Series Chipset Family On-Package CSME Keyboard and Text (KT) Redirection
+	a0e4  500 Series Chipset Family On-Package CSME HECI #3
+	a0e5  500 Series Chipset Family On-Package CSME HECI #4
+	a0e8  500 Series Chipset Family On-Package I2C Controller #0
+	a0e9  500 Series Chipset Family On-Package I2C Controller #1
+	a0ea  500 Series Chipset Family On-Package I2C Controller #2
+	a0eb  500 Series Chipset Family On-Package I2C Controller #3
+	a0ed  500 Series Chipset Family On-Package USB 3.2 Gen 2x1 (10 Gbs) xHCI Host Controller
+	a0ee  500 Series Chipset Family On-Package USB 3.2 Gen 1x1 (5 Gbs) Device Controller (xDCI)
+	a0ef  500 Series Chipset Family On-Package Shared SRAM
 	a0f0  Wi-Fi 6 AX201
 		8086 0244  Wi-Fi 6 AX101NGW
-	a0fc  Tiger Lake-LP Integrated Sensor Hub
+	a0fb  500 Series Chipset Family On-Package Generic SPI (GSPI) #2
+	a0fc  500 Series Chipset Family On-Package Integrated Sensor Hub
+	a0fd  500 Series Chipset Family On-Package Generic SPI (GSPI) #3
 	a102  Q170/Q150/B150/H170/H110/Z170/CM236 Chipset SATA Controller [AHCI Mode]
 		1043 8694  H110I-PLUS Motherboard
 		1462 7994  H110M ECO/GAMING
@@ -38491,65 +40544,65 @@
 	a106  Q170/H170/Z170/CM236 Chipset SATA Controller [RAID Mode]
 	a107  HM170/QM170 Chipset SATA Controller [RAID Mode]
 	a10f  Sunrise Point-H SATA Controller [RAID mode]
-	a110  100 Series/C230 Series Chipset Family PCI Express Root Port #1
-	a111  100 Series/C230 Series Chipset Family PCI Express Root Port #2
-	a112  100 Series/C230 Series Chipset Family PCI Express Root Port #3
-	a113  100 Series/C230 Series Chipset Family PCI Express Root Port #4
-	a114  100 Series/C230 Series Chipset Family PCI Express Root Port #5
+	a110  100/C230 Series Chipset Family PCIe Root Port #1
+	a111  100/C230 Series Chipset Family PCIe Root Port #2
+	a112  100/C230 Series Chipset Family PCIe Root Port #3
+	a113  100/C230 Series Chipset Family PCIe Root Port #4
+	a114  100/C230 Series Chipset Family PCIe Root Port #5
 		1043 8694  H110I-PLUS Motherboard
-	a115  100 Series/C230 Series Chipset Family PCI Express Root Port #6
-	a116  100 Series/C230 Series Chipset Family PCI Express Root Port #7
-	a117  100 Series/C230 Series Chipset Family PCI Express Root Port #8
-	a118  100 Series/C230 Series Chipset Family PCI Express Root Port #9
+	a115  100/C230 Series Chipset Family PCIe Root Port #6
+	a116  100/C230 Series Chipset Family PCIe Root Port #7
+	a117  100/C230 Series Chipset Family PCIe Root Port #8
+	a118  100/C230 Series Chipset Family PCIe Root Port #9
 		1043 8694  H110I-PLUS Motherboard
-	a119  100 Series/C230 Series Chipset Family PCI Express Root Port #10
+	a119  100/C230 Series Chipset Family PCIe Root Port #10
 		1043 8694  H110I-PLUS Motherboard
-	a11a  100 Series/C230 Series Chipset Family PCI Express Root Port #11
-	a11b  100 Series/C230 Series Chipset Family PCI Express Root Port #12
-	a11c  100 Series/C230 Series Chipset Family PCI Express Root Port #13
-	a11d  100 Series/C230 Series Chipset Family PCI Express Root Port #14
-	a11e  100 Series/C230 Series Chipset Family PCI Express Root Port #15
-	a11f  100 Series/C230 Series Chipset Family PCI Express Root Port #16
-	a120  100 Series/C230 Series Chipset Family P2SB
-	a121  100 Series/C230 Series Chipset Family Power Management Controller
+	a11a  100/C230 Series Chipset Family PCIe Root Port #11
+	a11b  100/C230 Series Chipset Family PCIe Root Port #12
+	a11c  100/C230 Series Chipset Family PCIe Root Port #13
+	a11d  100/C230 Series Chipset Family PCIe Root Port #14
+	a11e  100/C230 Series Chipset Family PCIe Root Port #15
+	a11f  100/C230 Series Chipset Family PCIe Root Port #16
+	a120  100/C230 Series Chipset Family P2SB
+	a121  100/C230 Series Chipset Family PMC
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
 		1043 8694  H110I-PLUS Motherboard
 		1462 7994  H110M ECO/GAMING
 	a122  Sunrise Point-H cAVS
-	a123  100 Series/C230 Series Chipset Family SMBus
+	a123  100/C230 Series Chipset Family SMBus
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
 		1043 8694  H110I-PLUS Motherboard
 		1462 7994  H110M ECO/GAMING
-	a124  100 Series/C230 Series Chipset Family SPI Controller
-	a125  100 Series/C230 Series Chipset Family Gigabit Ethernet Controller
-	a126  100 Series/C230 Series Chipset Family Trace Hub
-	a127  100 Series/C230 Series Chipset Family Serial IO UART #0
-	a128  100 Series/C230 Series Chipset Family Serial IO UART #1
-	a129  100 Series/C230 Series Chipset Family Serial IO GSPI #0
-	a12a  100 Series/C230 Series Chipset Family Serial IO GSPI #1
-	a12f  100 Series/C230 Series Chipset Family USB 3.0 xHCI Controller
+	a124  100/C230 Series Chipset Family SPI Controller
+	a125  100/C230 Series Chipset Family GbE Controller
+	a126  100/C230 Series Chipset Family Trace Hub
+	a127  100/C230 Series Chipset Family UART #0
+	a128  100/C230 Series Chipset Family UART #1
+	a129  100/C230 Series Chipset Family GSPI #0
+	a12a  100/C230 Series Chipset Family GSPI #1
+	a12f  100/C230 Series Chipset Family USB 3.0 xHCI Controller
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
 		1043 8694  H110I-PLUS Motherboard
 		1462 7994  H110M ECO/GAMING
-	a130  100 Series/C230 Series Chipset Family USB Device Controller (OTG)
-	a131  100 Series/C230 Series Chipset Family Thermal Subsystem
+	a130  100/C230 Series Chipset Family USB Device Controller (OTG)
+	a131  100/C230 Series Chipset Family Thermal Subsystem
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
 		1462 7994  H110M ECO/GAMING
 	a133  Sunrise Point-H Northpeak ACPI Function
-	a135  100 Series/C230 Series Chipset Family Integrated Sensor Hub
-	a13a  100 Series/C230 Series Chipset Family MEI Controller #1
+	a135  100/C230 Series Chipset Family ISH
+	a13a  100/C230 Series Chipset Family MEI #1
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
 		1043 8694  H110I-PLUS Motherboard
 		1462 7994  H110M ECO/GAMING
-	a13b  100 Series/C230 Series Chipset Family MEI Controller #2
-	a13c  100 Series/C230 Series Chipset Family IDE Redirection
-	a13d  100 Series/C230 Series Chipset Family KT Redirection
-	a13e  100 Series/C230 Series Chipset Family MEI Controller #3
+	a13b  100/C230 Series Chipset Family MEI #2
+	a13c  100/C230 Series Chipset Family IDE Redirection
+	a13d  100/C230 Series Chipset Family Keyboard and Text (KT) Redirection
+	a13e  100/C230 Series Chipset Family MEI #3
 	a140  Sunrise Point-H LPC Controller
 	a141  Sunrise Point-H LPC Controller
 	a142  Sunrise Point-H LPC Controller
@@ -38586,44 +40639,44 @@
 	a15d  Sunrise Point-H LPC Controller
 	a15e  Sunrise Point-H LPC Controller
 	a15f  Sunrise Point-H LPC Controller
-	a160  100 Series/C230 Series Chipset Family Serial IO I2C Controller #0
+	a160  100/C230 Series Chipset Family I2C #0
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
-	a161  100 Series/C230 Series Chipset Family Serial IO I2C Controller #1
+	a161  100/C230 Series Chipset Family I2C #1
 		1028 06e4  XPS 15 9550
-	a162  100 Series/C230 Series Chipset Family Serial IO I2C Controller #2
-	a163  100 Series/C230 Series Chipset Family Serial IO I2C Controller #3
-	a166  100 Series/C230 Series Chipset Family Serial IO UART Controller #2
-	a167  100 Series/C230 Series Chipset Family PCI Express Root Port #17
-	a168  100 Series/C230 Series Chipset Family PCI Express Root Port #18
-	a169  100 Series/C230 Series Chipset Family PCI Express Root Port #19
-	a16a  100 Series/C230 Series Chipset Family PCI Express Root Port #20
-	a170  100 Series/C230 Series Chipset Family HD Audio Controller
+	a162  100/C230 Series Chipset Family I2C #2
+	a163  100/C230 Series Chipset Family I2C #3
+	a166  100/C230 Series Chipset Family UART #2
+	a167  100/C230 Series Chipset Family PCIe Root Port #17
+	a168  100/C230 Series Chipset Family PCIe Root Port #18
+	a169  100/C230 Series Chipset Family PCIe Root Port #19
+	a16a  100/C230 Series Chipset Family PCIe Root Port #20
+	a170  100/C230 Series Chipset Family HD Audio
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
 		1043 86c7  H110I-PLUS Motherboard
 		1462 f994  H110M ECO/GAMING
-	a171  CM238 HD Audio Controller
-	a182  C620 Series Chipset Family SATA Controller [AHCI mode]
-	a186  C620 Series Chipset Family SATA Controller [RAID mode]
-	a190  C620 Series Chipset Family PCI Express Root Port #1
-	a191  C620 Series Chipset Family PCI Express Root Port #2
-	a192  C620 Series Chipset Family PCI Express Root Port #3
-	a193  C620 Series Chipset Family PCI Express Root Port #4
-	a194  C620 Series Chipset Family PCI Express Root Port #5
-	a195  C620 Series Chipset Family PCI Express Root Port #6
-	a196  C620 Series Chipset Family PCI Express Root Port #7
-	a197  C620 Series Chipset Family PCI Express Root Port #8
-	a198  C620 Series Chipset Family PCI Express Root Port #9
-	a199  C620 Series Chipset Family PCI Express Root Port #10
-	a19a  C620 Series Chipset Family PCI Express Root Port #11
-	a19b  C620 Series Chipset Family PCI Express Root Port #12
-	a19c  C620 Series Chipset Family PCI Express Root Port #13
-	a19d  C620 Series Chipset Family PCI Express Root Port #14
-	a19e  C620 Series Chipset Family PCI Express Root Port #15
-	a19f  C620 Series Chipset Family PCI Express Root Port #16
+	a171  HM175/QM175/CM238 HD Audio Controller
+	a182  C620 Series Chipset Family SATA Controller (AHCI)
+	a186  C620 Series Chipset Family SATA Controller (RAID 0/1/5/10)
+	a190  C620 Series Chipset Family PCIe Root Port #0
+	a191  C620 Series Chipset Family PCIe Root Port #1
+	a192  C620 Series Chipset Family PCIe Root Port #2
+	a193  C620 Series Chipset Family PCIe Root Port #3
+	a194  C620 Series Chipset Family PCIe Root Port #4
+	a195  C620 Series Chipset Family PCIe Root Port #5
+	a196  C620 Series Chipset Family PCIe Root Port #6
+	a197  C620 Series Chipset Family PCIe Root Port #7
+	a198  C620 Series Chipset Family PCIe Root Port #8
+	a199  C620 Series Chipset Family PCIe Root Port #9
+	a19a  C620 Series Chipset Family PCIe Root Port #10
+	a19b  C620 Series Chipset Family PCIe Root Port #11
+	a19c  C620 Series Chipset Family PCIe Root Port #12
+	a19d  C620 Series Chipset Family PCIe Root Port #13
+	a19e  C620 Series Chipset Family PCIe Root Port #14
+	a19f  C620 Series Chipset Family PCIe Root Port #15
 	a1a0  C620 Series Chipset Family P2SB
-	a1a1  C620 Series Chipset Family Power Management Controller
+	a1a1  C620 Series Chipset Family PMC
 		15d9 095d  X11SPM-TF
 	a1a2  C620 Series Chipset Family cAVS
 	a1a3  C620 Series Chipset Family SMBus
@@ -38635,131 +40688,155 @@
 		15d9 095d  X11SPM-TF
 	a1b1  C620 Series Chipset Family Thermal Subsystem
 		15d9 095d  X11SPM-TF
-	a1ba  C620 Series Chipset Family MEI Controller #1
+	a1ba  C620 Series Chipset Family MEI HECI #1
 		15d9 095d  X11SPM-TF
-	a1bb  C620 Series Chipset Family MEI Controller #2
+	a1bb  C620 Series Chipset Family MEI HECI #2
 		15d9 095d  X11SPM-TF
-	a1bc  C620 Series Chipset Family IDE Redirection
-	a1bd  C620 Series Chipset Family KT Redirection
-	a1be  C620 Series Chipset Family MEI Controller #3
+	a1bc  C620 Series Chipset Family MEI IDE Redirection
+	a1bd  C620 Series Chipset Family MEI Keyboard and Text (KT) Redirection
+	a1be  C620 Series Chipset Family MEI HECI #3
 		15d9 095d  X11SPM-TF
-	a1c1  C621 Series Chipset LPC/eSPI Controller
-	a1c2  C622 Series Chipset LPC/eSPI Controller
+	a1c1  C621 Chipset LPC/eSPI Controller
+	a1c2  C622 Chipset LPC/eSPI Controller
 		15d9 095d  X11SPM-TF
-	a1c3  C624 Series Chipset LPC/eSPI Controller
-	a1c4  C625 Series Chipset LPC/eSPI Controller
-	a1c5  C626 Series Chipset LPC/eSPI Controller
-	a1c6  C627 Series Chipset LPC/eSPI Controller
-	a1c7  C628 Series Chipset LPC/eSPI Controller
-	a1d2  C620 Series Chipset Family SSATA Controller [AHCI mode]
-	a1d6  C620 Series Chipset Family SSATA Controller [RAID mode]
-	a1e7  C620 Series Chipset Family PCI Express Root Port #17
-	a1e8  C620 Series Chipset Family PCI Express Root Port #18
-	a1e9  C620 Series Chipset Family PCI Express Root Port #19
-	a1ea  C620 Series Chipset Family PCI Express Root Port #20
+	a1c3  C624 Chipset LPC/eSPI Controller
+	a1c4  C625 Chipset LPC/eSPI Controller
+	a1c5  C626 Chipset LPC/eSPI Controller
+	a1c6  C627 Chipset LPC/eSPI Controller
+	a1c7  C628 Chipset LPC/eSPI Controller
+	a1ca  C629 Chipset LPC/eSPI Controller
+	a1d2  C620 Series Chipset Family SSATA Controller (AHCI)
+	a1d6  C620 Series Chipset Family SSATA Controller (RAID 0/1/5/10)
+	a1e7  C620 Series Chipset Family PCIe Root Port #16
+	a1e8  C620 Series Chipset Family PCIe Root Port #17
+	a1e9  C620 Series Chipset Family PCIe Root Port #18
+	a1ea  C620 Series Chipset Family PCIe Root Port #19
 	a1ec  C620 Series Chipset Family MROM 0
 	a1ed  C620 Series Chipset Family MROM 1
-	a1f0  C62x HD Audio Controller
-	a1f8  Lewisburg IE: HECI #1
-	a1f9  Lewisburg IE: HECI #2
-	a1fa  Lewisburg IE: IDE-r
-	a1fb  Lewisburg IE: KT Controller
-	a1fc  Lewisburg IE: HECI #3
-	a202  Lewisburg SATA Controller [AHCI mode]
-	a206  Lewisburg SATA Controller [RAID mode]
-	a210  Lewisburg PCI Express Root Port
-	a211  Lewisburg PCI Express Root Port
-	a212  Lewisburg PCI Express Root Port
-	a213  Lewisburg PCI Express Root Port
-	a214  Lewisburg PCI Express Root Port
-	a215  Lewisburg PCI Express Root Port
-	a216  Lewisburg PCI Express Root Port
-	a217  Lewisburg PCI Express Root Port
-	a218  Lewisburg PCI Express Root Port
-	a219  Lewisburg PCI Express Root Port
-	a21a  Lewisburg PCI Express Root Port
-	a21b  Lewisburg PCI Express Root Port
-	a21c  Lewisburg PCI Express Root Port
-	a21d  Lewisburg PCI Express Root Port
-	a21e  Lewisburg PCI Express Root Port
-	a21f  Lewisburg PCI Express Root Port
-	a221  Lewisburg Power Management Controller
-	a223  Lewisburg SMBus
-	a224  Lewisburg SPI Controller
-	a242  Lewisburg LPC or eSPI Controller
-	a243  Lewisburg LPC or eSPI Controller
-	a252  Lewisburg SSATA Controller [AHCI mode]
-	a256  Lewisburg SSATA Controller [RAID mode]
-	a267  Lewisburg PCI Express Root Port
-	a268  Lewisburg PCI Express Root Port
-	a269  Lewisburg PCI Express Root Port
-	a26a  Lewisburg PCI Express Root Port
-	a282  200 Series PCH SATA controller [AHCI mode]
+	a1f0  C620 Series Chipset Family HD Audio
+	a1f8  C620 Series Chipset Family IE HECI #1
+	a1f9  C620 Series Chipset Family IE HECI #2
+	a1fa  C620 Series Chipset Family IE IDE Redirection
+	a1fb  C620 Series Chipset Family IE Keyboard and Text Redirection
+	a1fc  C620 Series Chipset Family IE HECI #3
+	a202  C620 Series Chipset Family (Super) SATA Controller (AHCI)
+	a206  C620 Series Chipset Family (Super) SATA Controller (RAID 0/1/5/10)
+	a210  C620 Series Chipset Family (Super) PCIe Root Port #0
+	a211  C620 Series Chipset Family (Super) PCIe Root Port #1
+	a212  C620 Series Chipset Family (Super) PCIe Root Port #2
+	a213  C620 Series Chipset Family (Super) PCIe Root Port #3
+	a214  C620 Series Chipset Family (Super) PCIe Root Port #4
+	a215  C620 Series Chipset Family (Super) PCIe Root Port #5
+	a216  C620 Series Chipset Family (Super) PCIe Root Port #6
+	a217  C620 Series Chipset Family (Super) PCIe Root Port #7
+	a218  C620 Series Chipset Family (Super) PCIe Root Port #8
+	a219  C620 Series Chipset Family (Super) PCIe Root Port #9
+	a21a  C620 Series Chipset Family (Super) PCIe Root Port #10
+	a21b  C620 Series Chipset Family (Super) PCIe Root Port #11
+	a21c  C620 Series Chipset Family (Super) PCIe Root Port #12
+	a21d  C620 Series Chipset Family (Super) PCIe Root Port #13
+	a21e  C620 Series Chipset Family (Super) PCIe Root Port #14
+	a21f  C620 Series Chipset Family (Super) PCIe Root Port #15
+	a220  C620 Series Chipset Family (Super) P2SB
+	a221  C620 Series Chipset Family (Super) PMC
+	a223  C620 Series Chipset Family (Super) SMBus
+	a224  C620 Series Chipset Family (Super) SPI Controller
+	a226  C620 Series Chipset Family (Super) Trace Hub
+	a22f  C620 Series Chipset Family (Super) USB 3.0 xHCI Controller
+	a231  C620 Series Chipset Family (Super) Thermal Subsystem
+	a23a  C620 Series Chipset Family (Super) MEI HECI #1
+	a23b  C620 Series Chipset Family (Super) MEI HECI #2
+	a23c  C620 Series Chipset Family (Super) MEI IDE Redirection
+	a23d  C620 Series Chipset Family (Super) MEI Keyboard and Text (KT) Redirection
+	a23e  C620 Series Chipset Family (Super) MEI HECI #3
+	a242  C624 Chipset (Super) LPC/eSPI Controller
+	a243  C627 Chipset (Super) LPC/eSPI Controller
+	a244  C621 Chipset (Super) LPC/eSPI Controller
+	a245  C627 Chipset (Super) LPC/eSPI Controller
+	a246  C628 Chipset (Super) LPC/eSPI Controller
+	a252  C620 Series Chipset Family (Super) SSATA Controller (AHCI)
+	a256  C620 Series Chipset Family (Super) SSATA Controller (RAID 0/1/5/10)
+	a267  C620 Series Chipset Family (Super) PCIe Root Port #16
+	a268  C620 Series Chipset Family (Super) PCIe Root Port #17
+	a269  C620 Series Chipset Family (Super) PCIe Root Port #18
+	a26a  C620 Series Chipset Family (Super) PCIe Root Port #19
+	a26c  C620 Series Chipset Family (Super) MROM 0
+	a270  C620 Series Chipset Family (Super) Audio
+	a278  C620 Series Chipset Family (Super) IE HECI #1
+	a279  C620 Series Chipset Family (Super) IE HECI #2
+	a27a  C620 Series Chipset Family (Super) IE IDE Redirection
+	a27b  C620 Series Chipset Family (Super) IE Keyboard and Text Redirection
+	a27c  C620 Series Chipset Family (Super) IE HECI #3
+	a282  200 Series/Z370 Chipset Family SATA Controller (AHCI)
 		1462 7a72  H270 PC MATE
-	a286  200 Series PCH SATA controller [RAID mode]
-	a290  200 Series PCH PCI Express Root Port #1
-	a291  200 Series PCH PCI Express Root Port #2
-	a292  200 Series PCH PCI Express Root Port #3
-	a293  200 Series PCH PCI Express Root Port #4
-	a294  200 Series PCH PCI Express Root Port #5
+	a286  200 Series/Z370 Chipset Family SATA Controller (RAID) Premium
+	a28e  200 Series/Z370 Chipset Family SATA Controller (RST and Optane Technology)
+	a290  200 Series/Z370 Chipset Family PCIe Root Port #1
+	a291  200 Series/Z370 Chipset Family PCIe Root Port #2
+	a292  200 Series/Z370 Chipset Family PCIe Root Port #3
+	a293  200 Series/Z370 Chipset Family PCIe Root Port #4
+	a294  200 Series/Z370 Chipset Family PCIe Root Port #5
 		1462 7a72  H270 PC MATE
-	a295  200 Series PCH PCI Express Root Port #6
-	a296  200 Series PCH PCI Express Root Port #7
+	a295  200 Series/Z370 Chipset Family PCIe Root Port #6
+	a296  200 Series/Z370 Chipset Family PCIe Root Port #7
 		1462 7a72  H270 PC MATE
-	a297  200 Series PCH PCI Express Root Port #8
-	a298  200 Series PCH PCI Express Root Port #9
+	a297  200 Series/Z370 Chipset Family PCIe Root Port #8
+	a298  200 Series/Z370 Chipset Family PCIe Root Port #9
 		1462 7a72  H270 PC MATE
-	a299  200 Series PCH PCI Express Root Port #10
-	a29a  200 Series PCH PCI Express Root Port #11
-	a29b  200 Series PCH PCI Express Root Port #12
-	a29c  200 Series PCH PCI Express Root Port #13
-	a29d  200 Series PCH PCI Express Root Port #14
-	a29e  200 Series PCH PCI Express Root Port #15
-	a29f  200 Series PCH PCI Express Root Port #16
+	a299  200 Series/Z370 Chipset Family PCIe Root Port #10
+	a29a  200 Series/Z370 Chipset Family PCIe Root Port #11
+	a29b  200 Series/Z370 Chipset Family PCIe Root Port #12
+	a29c  200 Series/Z370 Chipset Family PCIe Root Port #13
+	a29d  200 Series/Z370 Chipset Family PCIe Root Port #14
+	a29e  200 Series/Z370 Chipset Family PCIe Root Port #15
+	a29f  200 Series/Z370 Chipset Family PCIe Root Port #16
 	a2a0  200 Series/Z370 Chipset Family P2SB
-	a2a1  200 Series/Z370 Chipset Family Power Management Controller
+	a2a1  200 Series/Z370 Chipset Family PMC
 		1462 7a72  H270 PC MATE
-	a2a3  200 Series/Z370 Chipset Family SMBus Controller
+	a2a3  200 Series/Z370 Chipset Family SMBus
 		1462 7a72  H270 PC MATE
 	a2a4  200 Series/Z370 Chipset Family SPI Controller
-	a2a5  200 Series/Z370 Chipset Family Gigabit Ethernet Controller
+	a2a5  200 Series/Z370 Chipset Family GbE Controller
 	a2a6  200 Series/Z370 Chipset Family Trace Hub
-	a2a7  200 Series/Z370 Chipset Family Serial IO UART Controller #0
-	a2a8  200 Series/Z370 Chipset Family Serial IO UART Controller #1
-	a2a9  200 Series/Z370 Chipset Family Serial IO SPI Controller #0
-	a2aa  200 Series/Z370 Chipset Family Serial IO SPI Controller #1
+	a2a7  200 Series/Z370 Chipset Family UART #0
+	a2a8  200 Series/Z370 Chipset Family UART #1
+	a2a9  200 Series/Z370 Chipset Family GSPI #0
+	a2aa  200 Series/Z370 Chipset Family GSPI #1
 	a2af  200 Series/Z370 Chipset Family USB 3.0 xHCI Controller
 		1462 7a72  H270 PC MATE
-	a2b1  200 Series PCH Thermal Subsystem
+	a2b0  200 Series/Z370 Chipset Family USB Device Controller (OTG)
+	a2b1  200 Series/Z370 Chipset Family Thermal Subsystem
 		1462 7a72  H270 PC MATE
-	a2ba  200 Series PCH CSME HECI #1
+	a2b5  200 Series/Z370 Chipset Family ISH
+	a2ba  200 Series/Z370 Chipset Family MEI #1
 		1462 7a72  H270 PC MATE
-	a2bb  200 Series PCH CSME HECI #2
-# AMT serial over LAN
-	a2bd  200 Series Chipset Family KT Redirection
-	a2c4  200 Series PCH LPC Controller (H270)
+	a2bb  200 Series/Z370 Chipset Family MEI #2
+	a2bc  200 Series/Z370 Chipset Family IDE Redirection
+	a2bd  200 Series/Z370 Chipset Family Keyboard and Text (KT) Redirection
+	a2be  200 Series/Z370 Chipset Family MEI #3
+	a2c4  H270 Chipset LPC/eSPI Controller
 		1462 7a72  H270 PC MATE
-	a2c5  200 Series PCH LPC Controller (Z270)
-	a2c6  200 Series PCH LPC Controller (Q270)
-	a2c7  200 Series PCH LPC Controller (Q250)
-	a2c8  200 Series PCH LPC Controller (B250)
+	a2c5  Z270 Chipset LPC/eSPI Controller
+	a2c6  Q270 Chipset LPC/eSPI Controller
+	a2c7  Q250 Chipset LPC/eSPI Controller
+	a2c8  B250 Chipset LPC/eSPI Controller
 	a2c9  Z370 Chipset LPC/eSPI Controller
 	a2d2  X299 Chipset LPC/eSPI Controller
 	a2d3  C422 Chipset LPC/eSPI Controller
-	a2e0  200 Series PCH Serial IO I2C Controller #0
-	a2e1  200 Series PCH Serial IO I2C Controller #1
-	a2e2  200 Series PCH Serial IO I2C Controller #2
-	a2e3  200 Series PCH Serial IO I2C Controller #3
-	a2e6  200 Series PCH Serial IO UART Controller #2
-	a2e7  200 Series PCH PCI Express Root Port #17
-	a2e8  200 Series PCH PCI Express Root Port #18
-	a2e9  200 Series PCH PCI Express Root Port #19
-	a2ea  200 Series PCH PCI Express Root Port #20
-	a2eb  200 Series PCH PCI Express Root Port #21
-	a2ec  200 Series PCH PCI Express Root Port #22
-	a2ed  200 Series PCH PCI Express Root Port #23
-	a2ee  200 Series PCH PCI Express Root Port #24
-	a2f0  200 Series PCH HD Audio
+	a2e0  200 Series/Z370 Chipset Family I2C #0
+	a2e1  200 Series/Z370 Chipset Family I2C #1
+	a2e2  200 Series/Z370 Chipset Family I2C #2
+	a2e3  200 Series/Z370 Chipset Family I2C #3
+	a2e6  200 Series/Z370 Chipset Family UART #2
+	a2e7  200 Series/Z370 Chipset Family PCIe Root Port #17
+	a2e8  200 Series/Z370 Chipset Family PCIe Root Port #18
+	a2e9  200 Series/Z370 Chipset Family PCIe Root Port #19
+	a2ea  200 Series/Z370 Chipset Family PCIe Root Port #20
+	a2eb  200 Series/Z370 Chipset Family PCIe Root Port #21
+	a2ec  200 Series/Z370 Chipset Family PCIe Root Port #22
+	a2ed  200 Series/Z370 Chipset Family PCIe Root Port #23
+	a2ee  200 Series/Z370 Chipset Family PCIe Root Port #24
+	a2f0  200 Series/Z370 Chipset Family HD Audio
 		1462 7a72  H270 PC MATE
 		1462 fa72  H270 PC MATE
 	a303  H310 Chipset LPC/eSPI Controller
@@ -38775,72 +40852,139 @@
 	a30d  HM370 Chipset LPC/eSPI Controller
 	a30e  CM246 Chipset LPC/eSPI Controller
 	a313  Cannon Lake LPC/eSPI Controller
-	a323  Cannon Lake PCH SMBus Controller
+	a320  300/C240 Series Chipset Family P2SB
+	a321  300/C240 Series Chipset Family PMC
+	a323  300/C240 Series Chipset Family SMBus
 		1028 0869  Vostro 3470
-	a324  Cannon Lake PCH SPI Controller
+	a324  300/C240 Series Chipset Family SPI (Flash) Controller
 		1028 0869  Vostro 3470
-	a328  Cannon Lake PCH Serial IO UART Host Controller
-	a32b  Cannon Lake PCH SPI Host Controller
-	a32c  Cannon Lake PCH PCI Express Root Port #21
-	a32d  Cannon Lake PCH PCI Express Root Port #22
-	a32e  Cannon Lake PCH PCI Express Root Port #23
-	a32f  Cannon Lake PCH PCI Express Root Port #24
-	a330  Cannon Lake PCH PCI Express Root Port #9
-	a331  Cannon Lake PCH PCI Express Root Port #10
-	a332  Cannon Lake PCH PCI Express Root Port #11
-	a333  Cannon Lake PCH PCI Express Root Port #12
-	a334  Cannon Lake PCH PCI Express Root Port #13
-	a335  Cannon Lake PCH PCI Express Root Port #14
-	a336  Cannon Lake PCH PCI Express Root Port #15
-	a337  Cannon Lake PCH PCI Express Root Port #16
-	a338  Cannon Lake PCH PCI Express Root Port #1
-	a339  Cannon Lake PCH PCI Express Root Port #2
-	a33a  Cannon Lake PCH PCI Express Root Port #3
-	a33b  Cannon Lake PCH PCI Express Root Port #4
-	a33c  Cannon Lake PCH PCI Express Root Port #5
-	a33d  Cannon Lake PCH PCI Express Root Port #6
-	a33e  Cannon Lake PCH PCI Express Root Port #7
-	a33f  Cannon Lake PCH PCI Express Root Port #8
-	a340  Cannon Lake PCH PCI Express Root Port #17
-	a341  Cannon Lake PCH PCI Express Root Port #18
-	a342  Cannon Lake PCH PCI Express Root Port #19
-	a343  Cannon Lake PCH PCI Express Root Port #20
-	a348  Cannon Lake PCH cAVS
+	a326  300/C240 Series Chipset Family Trace Hub
+	a328  300/C240 Series Chipset Family UART #0
+	a329  300/C240 Series Chipset Family UART #1
+	a32a  300/C240 Series Chipset Family GSPI #0
+	a32b  300/C240 Series Chipset Family GSPI #1
+	a32c  300/C240 Series Chipset Family PCIe Root Port #21
+	a32d  300/C240 Series Chipset Family PCIe Root Port #22
+	a32e  300/C240 Series Chipset Family PCIe Root Port #23
+	a32f  300/C240 Series Chipset Family PCIe Root Port #24
+	a330  300/C240 Series Chipset Family PCIe Root Port #9
+	a331  300/C240 Series Chipset Family PCIe Root Port #10
+	a332  300/C240 Series Chipset Family PCIe Root Port #11
+	a333  300/C240 Series Chipset Family PCIe Root Port #12
+	a334  300/C240 Series Chipset Family PCIe Root Port #13
+	a335  300/C240 Series Chipset Family PCIe Root Port #14
+	a336  300/C240 Series Chipset Family PCIe Root Port #15
+	a337  300/C240 Series Chipset Family PCIe Root Port #16
+	a338  300/C240 Series Chipset Family PCIe Root Port #1
+	a339  300/C240 Series Chipset Family PCIe Root Port #2
+	a33a  300/C240 Series Chipset Family PCIe Root Port #3
+	a33b  300/C240 Series Chipset Family PCIe Root Port #4
+	a33c  300/C240 Series Chipset Family PCIe Root Port #5
+	a33d  300/C240 Series Chipset Family PCIe Root Port #6
+	a33e  300/C240 Series Chipset Family PCIe Root Port #7
+	a33f  300/C240 Series Chipset Family PCIe Root Port #8
+	a340  300/C240 Series Chipset Family PCIe Root Port #17
+	a341  300/C240 Series Chipset Family PCIe Root Port #18
+	a342  300/C240 Series Chipset Family PCIe Root Port #19
+	a343  300/C240 Series Chipset Family PCIe Root Port #20
+	a347  300/C240 Series Chipset Family UART #2
+	a348  300/C240 Series Chipset Family HD Audio
 		1028 0869  Vostro 3470
-	a352  Cannon Lake PCH SATA AHCI Controller
+	a352  300/C240 Series Chipset Family SATA Controller (AHCI)
 		1028 0869  Vostro 3470
-	a353  Cannon Lake Mobile PCH SATA AHCI Controller
-	a360  Cannon Lake PCH HECI Controller
+	a353  300/C240 Series Chipset Family SATA Controller (AHCI)
+	a355  300/C240 Series Chipset Family SATA Controller (RAID 0/1/5/10)
+	a356  300/C240 Series Chipset Family SATA Controller (RAID 0/1/5/10)
+	a357  300/C240 Series Chipset Family SATA Controller (RAID 0/1/5/10)
+	a35e  300/C240 Series Chipset Family SATA Controller Optane Memory
+	a360  300/C240 Series Chipset Family HECI #1
 		1028 0869  Vostro 3470
-	a363  Cannon Lake PCH Active Management Technology - SOL
-	a364  Cannon Lake PCH HECI Controller #2
-	a368  Cannon Lake PCH Serial IO I2C Controller #0
-	a369  Cannon Lake PCH Serial IO I2C Controller #1
-	a36a  Cannon Lake PCH Serial IO I2C Controller #2
-	a36b  Cannon Lake PCH Serial IO I2C Controller #3
-	a36d  Cannon Lake PCH USB 3.1 xHCI Host Controller
+	a361  300/C240 Series Chipset Family HECI #2
+	a362  300/C240 Series Chipset Family IDE Redirection (IDER-R)
+	a363  300/C240 Series Chipset Family Keyboard and Text (KT) Redirection
+	a364  300/C240 Series Chipset Family HECI #3
+	a365  300/C240 Series Chipset Family HECI #4
+	a368  300/C240 Series Chipset Family I2C Controller #0
+	a369  300/C240 Series Chipset Family I2C Controller #1
+	a36a  300/C240 Series Chipset Family I2C Controller #2
+	a36b  300/C240 Series Chipset Family I2C Controller #3
+	a36d  300/C240 Series Chipset Family USB 3.1 xHCI
 		1028 0869  Vostro 3470
-	a36f  Cannon Lake PCH Shared SRAM
-	a370  Cannon Lake PCH CNVi WiFi
+	a36e  300/C240 Series Chipset Family USB Device Controller (Dual Role)
+	a36f  300/C240 Series Chipset Family Shared SRAM
+	a370  300/C240 Series Chipset Family CNVi Wi-Fi
 		1a56 1552  Killer(R) Wireless-AC 1550i Wireless Network Adapter (9560NGW)
 		8086 0034  Wireless-AC 9560
-	a379  Cannon Lake PCH Thermal Controller
+	a371  300/C240 Series Chipset Family CNVi Wi-Fi
+	a372  300/C240 Series Chipset Family CNVi Wi-Fi
+	a373  300/C240 Series Chipset Family CNVi Wi-Fi
+	a379  300/C240 Series Chipset Family Thermal Subsystem
 		1028 0869  Vostro 3470
-	a382  400 Series Chipset Family SATA AHCI Controller
-	a394  Comet Lake PCI Express Root Port #05
-	a397  Comet Lake PCI Express Root Port #08
-	a398  Comet Lake PCI Express Root Port 9
-	a39a  Comet Lake PCI Express Root Port 11
-	a3a1  Cannon Lake PCH Power Management Controller
-	a3a3  Comet Lake PCH-V SMBus Host Controller
-	a3af  Comet Lake PCH-V USB Controller
-	a3b1  Comet Lake PCH-V Thermal Subsystem
-	a3ba  Comet Lake PCH-V HECI Controller
+	a37b  300/C240 Series Chipset Family SPI #2
+	a37c  300/C240 Series Chipset Family Integrated Sensor Hub
+	a382  B460/H410 Chipset SATA Controller (AHCI)
+	a384  B460/H410 Chipset SATA Controller (RAID 0/1/5/10) Not Premium
+	a386  B460/H410 Chipset SATA Controller (RAID 0/1/5/10) Premium
+	a38e  B460/H410 Chipset SATA Controller (RST Optane)
+	a390  B460/H410 Chipset PCIe Root Port #1
+	a391  B460/H410 Chipset PCIe Root Port #2
+	a392  B460/H410 Chipset PCIe Root Port #3
+	a393  B460/H410 Chipset PCIe Root Port #4
+	a394  B460/H410 Chipset PCIe Root Port #5
+	a395  B460/H410 Chipset PCIe Root Port #6
+	a396  B460/H410 Chipset PCIe Root Port #7
+	a397  B460/H410 Chipset PCIe Root Port #8
+	a398  B460/H410 Chipset PCIe Root Port #9
+	a399  B460/H410 Chipset PCIe Root Port #10
+	a39a  B460/H410 Chipset PCIe Root Port #11
+	a39b  B460/H410 Chipset PCIe Root Port #12
+	a39c  B460/H410 Chipset PCIe Root Port #13
+	a39d  B460/H410 Chipset PCIe Root Port #14
+	a39e  B460/H410 Chipset PCIe Root Port #15
+	a39f  B460/H410 Chipset PCIe Root Port #16
+	a3a0  B460/H410 Chipset P2SB
+	a3a1  B460/H410 Chipset PMC
+	a3a3  B460/H410 Chipset SMBus
+	a3a4  B460/H410 Chipset SPI Controller
+	a3a6  B460/H410 Chipset Trace Hub
+	a3a7  B460/H410 Chipset UART #0
+	a3a8  B460/H410 Chipset UART #1
+	a3a9  B460/H410 Chipset SPI #0
+	a3aa  B460/H410 Chipset SPI #1
+	a3af  B460/H410 Chipset USB 3.2 Gen 1x1 (5 Gbs) xHCI Controller
+	a3b0  B460/H410 Chipset USB Device Controller
+	a3b1  B460/H410 Chipset Thermal Subsystem
+	a3b5  B460/H410 Chipset ISH
+	a3ba  B460/H410 Chipset CSME HECI #1
+	a3bb  B460/H410 Chipset CSME HECI #2
+	a3bc  B460/H410 Chipset CSME IDE Redirection
+	a3bd  B460/H410 Chipset CSME Keyboard and Text (KT) Redirection
+	a3be  B460/H410 Chipset CSME HECI #3
 	a3c8  B460 Chipset LPC/eSPI Controller
 	a3da  H410 Chipset LPC/eSPI Controller
-	a3eb  Comet Lake PCI Express Root Port #21
-	a3f0  Comet Lake PCH-V cAVS
+	a3e0  B460/H410 Chipset I2C #0
+	a3e1  B460/H410 Chipset I2C #1
+	a3e2  B460/H410 Chipset I2C #2
+	a3e3  B460/H410 Chipset I2C #3
+	a3e6  B460/H410 Chipset UART #2
+	a3e7  B460/H410 Chipset PCIe Root Port #17
+	a3e8  B460/H410 Chipset PCIe Root Port #18
+	a3e9  B460/H410 Chipset PCIe Root Port #19
+	a3ea  B460/H410 Chipset PCIe Root Port #20
+	a3eb  B460/H410 Chipset PCIe Root Port #21
+	a3ec  B460/H410 Chipset PCIe Root Port #22
+	a3ed  B460/H410 Chipset PCIe Root Port #23
+	a3ee  B460/H410 Chipset PCIe Root Port #24
+	a3f0  B460/H410 Chipset HD Audio
+	a3f1  B460/H410 Chipset HD Audio
+	a3f2  B460/H410 Chipset HD Audio
+	a3f3  B460/H410 Chipset HD Audio
+	a3f4  B460/H410 Chipset HD Audio
+	a3f5  B460/H410 Chipset HD Audio
+	a3f6  B460/H410 Chipset HD Audio
+	a3f7  B460/H410 Chipset HD Audio
 	a620  6400/6402 Advanced Memory Buffer (AMB)
+	a700  Raptor Lake-S Host Bridge/DRAM Controller
 	a703  Raptor Lake-S Host Bridge/DRAM Controller
 	a706  Raptor Lake-P 6p+8e cores Host Bridge/DRAM Controller
 		1028 0c06  Precision 3580
@@ -38858,7 +41002,7 @@
 	a73e  Raptor Lake-P Thunderbolt 4 NHI #0
 		1028 0c06  Precision 3580
 	a740  Raptor Lake-S 8+12 - Host Bridge/DRAM Controller
-	a74d  Raptor Lake PCIe 4.0 Graphics Port
+	a74d  Raptor Lake PCI Express 4.0 Graphics Port
 	a74f  GNA Scoring Accelerator module
 		1028 0c06  Precision 3580
 	a75d  Raptor Lake IPU
@@ -38866,7 +41010,7 @@
 	a76e  Raptor Lake-P Thunderbolt 4 PCI Express Root Port #0
 	a77d  Raptor Lake Crashlog and Telemetry
 		1028 0c06  Precision 3580
-	a77f  Volume Management Device NVMe RAID Controller Intel Corporation
+	a77f  RST Volume Management Device Controller
 	a780  Raptor Lake-S GT1 [UHD Graphics 770]
 	a781  Raptor Lake-S UHD Graphics
 	a782  Raptor Lake-S UHD Graphics
@@ -38885,57 +41029,104 @@
 	a7ac  Raptor Lake-U [Intel Graphics]
 	a7ad  Raptor Lake-U [Intel Graphics]
 	a806  Lunar Lake-M LPC/eSPI Controller
+	a807  Core Ultra 200V Series Processors eSPI Controller
+	a820  Core Ultra 200V Series Processors P2SB (8 bit)
+	a821  Core Ultra 200V Series Processors PMC
 	a822  Lunar Lake-M SMbus Controller
-	a823  Lunar Lake-M SPI Controller
-	a824  Lunar Lake-M Trace Hub
-	a825  Lunar Lake-M Serial IO UART Controller #0
-	a826  Lunar Lake-M Serial IO UART Controller #1
-	a827  Lunar Lake-M Serial IO SPI Controller #0
-	a828  Lunar Lake-M HD Audio Controller
-	a830  Lunar Lake-M Serial IO SPI Controller #1
-	a831  Lunar Lake-M Thunderbolt 4 USB Controller
-	a833  Lunar Lake-M Thunderbolt 4 NHI #0
-	a834  Lunar Lake-M Thunderbolt 4 NHI #1
-	a838  Lunar Lake-M PCI Express Root Port #1
-	a839  Lunar Lake-M PCI Express Root Port #2
-	a83a  Lunar Lake-M PCI Express Root Port #3
-	a83b  Lunar Lake-M PCI Express Root Port #4
-	a83c  Lunar Lake-M PCI Express Root Port #5
-	a83d  Lunar Lake-M PCI Express Root Port #6
-	a840  BE201 320MHz
-	a845  Lunar Lake-M Integrated Sensor Hub
+	a823  Core Ultra 200V Series Processors SPI (flash) Controller
+	a824  Core Ultra 200V Series Processors Trace Hub
+	a825  Core Ultra 200V Series Processors UART #0
+	a826  Core Ultra 200V Series Processors UART #1
+	a827  Core Ultra 200V Series Processors GSPI #0
+	a828  Core Ultra 200V Series Processors HD Audio
+	a830  Core Ultra 200V Series Processors GSPI #1
+	a831  Core Ultra 200V Series Processors Type-C Subsystem xHCI
+	a833  Core Ultra 200V Series Processors Thunderbolt DMA0
+	a834  Core Ultra 200V Series Processors Thunderbolt DMA1
+	a838  Core Ultra 200V Series Processors PCIe Root Port #1
+	a839  Core Ultra 200V Series Processors PCIe Root Port #2
+	a83a  Core Ultra 200V Series Processors PCIe Root Port #3
+	a83b  Core Ultra 200V Series Processors PCIe Root Port #4
+	a83c  Core Ultra 200V Series Processors PCIe Root Port #5
+	a83d  Core Ultra 200V Series Processors PCIe Root Port #6
+	a840  BE200 Series Wi-Fi 7
+	a845  Core Ultra 200V Series Processors Integrated Sensor Hub (ISH)
+	a846  Core Ultra 200V Series Processors GSPI #2
 	a847  Lunar Lake-M UFS Controller
-	a848  Lunar Lake-M Touch Host Controller #0 ID1
-	a849  Lunar Lake-M Touch Host Controller #0 ID2
-	a84a  Lunar Lake-M Touch Host Controller #1 ID1
-	a84b  Lunar Lake-M Touch Host Controller #1 ID2
-	a84e  Lunar Lake-M Thunderbolt 4 PCI Express Root Port #0
-	a84f  Lunar Lake-M Thunderbolt 4 PCI Express Root Port #1
-	a860  Lunar Lake-M Thunderbolt 4 PCI Express Root Port #2
-	a870  Lunar Lake-M CSME HECI #1
-	a873  Lunar Lake-M Keyboard and Text (KT) Redirection
-	a878  Lunar Lake-M Serial IO I2C Controller #0
-	a879  Lunar Lake-M Serial IO I2C Controller #1
-	a87a  Lunar Lake-M Serial IO I2C Controller #2
-	a87b  Lunar Lake-M Serial IO I2C Controller #3
-	a87d  Lunar Lake-M USB 3.2 Gen 2x1 xHCI Host Controller
-	a87f  Lunar Lake-M Shared SRAM
+	a848  Core Ultra 200V Series Processors Touch Host Controller (THC) #0 ID1
+	a849  Core Ultra 200V Series Processors Touch Host Controller (THC) #0 ID2
+	a84a  Core Ultra 200V Series Processors Touch Host Controller (THC) #1 ID1
+	a84b  Core Ultra 200V Series Processors Touch Host Controller (THC) #1 ID2
+	a84c  Core Ultra 200V Series Processors P2SB (16 bit)
+	a84e  Core Ultra 200V Series Processors USB Type-C Subsystem PCIe Root Port #21
+	a84f  Core Ultra 200V Series Processors USB Type-C Subsystem PCIe Root Port #22
+	a850  Core Ultra 200V Series Processors I2C #4
+	a851  Core Ultra 200V Series Processors I2C #5
+	a852  Core Ultra 200V Series Processors UART #2
+	a85d  Core Ultra 200V Series Processors CSME HECI #1
+	a85e  Core Ultra 200V Series Processors CSME HECI #2
+	a85f  Core Ultra 200V Series Processors CSME HECI #3
+	a860  Core Ultra 200V Series Processors USB Type-C Subsystem PCIe Root Port #23
+	a862  Core Ultra 200V Series Processors CSME HECI #1
+	a863  Core Ultra 200V Series Processors CSME HECI #2
+	a864  Core Ultra 200V Series Processors CSME HECI #3
+	a870  Core Ultra 200V Series Processors CSME HECI #1 (CSE)
+	a871  Core Ultra 200V Series Processors CSME HECI #2 (CSE)
+	a872  Core Ultra 200V Series Processors CSME IDE Redirection (IDE-R)
+	a873  Core Ultra 200V Series Processors CSME Keyboard and Text (KT) Redirection
+	a874  Core Ultra 200V Series Processors CSME HECI #3 (CSE)
+	a875  Core Ultra 200V Series Processors CSME HECI #4 (CSE)
+	a877  Core Ultra 200V Series Processors I3C #2
+	a878  Core Ultra 200V Series Processors I2C #0
+	a879  Core Ultra 200V Series Processors I2C #1
+	a87a  Core Ultra 200V Series Processors I2C #2
+	a87b  Core Ultra 200V Series Processors I2C #3
+	a87c  Core Ultra 200V Series Processors I3C #1
+	a87d  Core Ultra 200V Series Processors Standalone xHCI Controller
+	a87f  Core Ultra 200V Series Processors Shared SRAM
 	abc0  Omni-Path Fabric Switch Silicon 100 Series
-	ad0b  Volume Management Device NVMe RAID Controller Intel Corporation
-	ad1d  Arrow Lake NPU
-	b03e  Panther Lake NPU
-	b080  Panther Lake [Intel Graphics]
-	b081  Panther Lake [Intel Graphics]
-	b082  Panther Lake [Intel Graphics]
-	b083  Panther Lake [Intel Graphics]
-	b084  Panther Lake [Intel Graphics]
-	b085  Panther Lake [Intel Graphics]
-	b086  Panther Lake [Intel Graphics]
-	b087  Panther Lake [Intel Graphics]
+	ad03  Core Ultra 200 Series Processors Dynamic Tuning Technology (DTT)
+	ad0b  Core Ultra 200 Series Processors VMD
+	ad0d  Core Ultra 200 Series Processors Crash Log and Telemetry
+	ad1d  Core Ultra 200 Series Processors NPU
+	ae10  Arrow Lake-HX Direct eSPI Controller
+	ae20  Core Ultra 200 Series Processors P2SB (SOC-S)
+	ae21  Core Ultra 200 Series Processors PMC (SOC-S)
+	ae22  Core Ultra 200 Series Processors SMBus
+	ae23  Core Ultra 200 Series Processors SPI (flash) Controller
+	ae24  Core Ultra 200 Series Processors Trace Hub
+	ae4c  Core Ultra 200 Series Processors Gauss Newton Algorithm (GNA)
+	ae4d  Core Ultra 200 Series Processors PCIe Root Port #13
+	ae4e  Core Ultra 200 Series Processors PCIe Root Port #14
+	ae4f  Core Ultra 200 Series Processors PCIe Root Port #15
+	ae70  Core Ultra 200 Series Processors CSME HECI #1
+	ae71  Core Ultra 200 Series Processors CSME HECI #2
+	ae74  Core Ultra 200 Series Processors CSME HECI #3
+	ae7f  Core Ultra 200 Series Processors Shared SRAM (SOC-S)
+	b000  Core Ultra Processors (Series 3) PTL-404
+	b001  Core Ultra Processors (Series 3) PTL-H12Xe
+	b002  Core Ultra Processors (Series 3) PTL-H484
+	b003  Core Ultra Processors (Series 3) PTL-204
+	b004  Core Ultra Processors (Series 3) PTL-H444
+	b005  Core Ultra Processors (Series 3) PTL-H444
+	b01d  Core Ultra Processors (Series 3) DTT
+	b02d  Core Ultra Processors (Series 3) IAA
+	b03e  Core Ultra Processors (Series 3) NPU
+	b05d  Core Ultra Processors (Series 3) IPU
+	b07d  Core Ultra Processors (Series 3) Crashlog and Telemetry
+	b080  Panther Lake [Arc B390]
+	b081  Panther Lake [Arc B370]
+	b082  Panther Lake [Arc B390]
+	b083  Panther Lake [Arc B370]
+	b084  Panther Lake [Arc Pro B390]
+	b085  Panther Lake [Arc Pro B370]
+	b086  Panther Lake [Arc Pro B390]
+	b087  Panther Lake [Arc Pro B370]
 	b08f  Panther Lake [Intel Graphics]
 	b090  Panther Lake [Intel Graphics]
 	b0a0  Panther Lake [Intel Graphics]
 	b0b0  Panther Lake [Intel Graphics]
+	b0ff  Panther Lake [Intel Graphics]
 	b152  21152 PCI-to-PCI Bridge
 		8086 b152  21152 PCI-to-PCI Bridge
 # observed, and documented in Intel revision note; new mask of 1011:0026
@@ -38973,19 +41164,220 @@
 	d156  Core Processor Semaphore and Scratchpad Registers
 	d157  Core Processor System Control and Status Registers
 	d158  Core Processor Miscellaneous Registers
+	d323  Nova Lake PCD-H SPI Controller
+	d325  Nova Lake PCD-H Serial IO UART Controller #0
+	d326  Nova Lake PCD-H Serial IO UART Controller #1
+	d327  Nova Lake PCD-H Serial IO SPI Controller #0
+	d330  Nova Lake PCD-H Serial IO SPI Controller #1
+	d331  Nova Lake-H Thunderbolt 5 USB Controller
+	d333  Nova Lake-H Thunderbolt 5 NHI #0
+	d347  Nova Lake PCD-H Serial IO SPI Controller #2
+	d34e  Nova Lake-H Thunderbolt 5 PCI Express Root Port #0
+	d34f  Nova Lake-H Thunderbolt 5 PCI Express Root Port #1
+	d350  Nova Lake PCD-H Serial IO I2C Controller #4
+	d351  Nova Lake PCD-H Serial IO I2C Controller #5
+	d352  Nova Lake PCD-H Serial IO UART Controller #2
+	d360  Nova Lake-H Thunderbolt 5 PCI Express Root Port #2
+	d378  Nova Lake PCD-H Serial IO I2C Controller #0
+	d379  Nova Lake PCD-H Serial IO I2C Controller #1
+	d37a  Nova Lake PCD-H Serial IO I2C Controller #2
+	d37b  Nova Lake PCD-H Serial IO I2C Controller #3
+	d431  Nova Lake-S Thunderbolt 5 USB Controller
+	d433  Nova Lake-S Thunderbolt 5 NHI #0
+	d44e  Nova Lake-S Thunderbolt 5 PCI Express Root Port #0
+	d44f  Nova Lake-S Thunderbolt 5 PCI Express Root Port #1
+	d460  Nova Lake-S Thunderbolt 5 PCI Express Root Port #2
+	d740  NVL-S
+	d741  NVL-U
+	d742  NVL-H
+	d743  NVL-HX
+	d744  NVL-UL
+	d745  NVL-HX
+	d74a  NVL-S
+	d74b  NVL-S
+	d750  NVL-P
+	d751  NVL-P
+	d752  NVL-P
+	d753  NVL-P
+	d754  NVL-P
+	d755  NVL-P
+	d756  NVL-P
+	d757  NVL-P
+	d75f  NVL-P
 	e202  Battlemage G21 [Intel Graphics]
 	e20b  Battlemage G21 [Arc B580]
 	e20c  Battlemage G21 [Arc B570]
 	e20d  Battlemage G21 [Intel Graphics]
 	e210  Battlemage G21 [Intel Graphics]
-	e211  Battlemage G21 [Intel Graphics]
-	e212  Battlemage G21 [Intel Graphics]
+	e211  Battlemage G21 [Arc Pro B60]
+	e212  Battlemage G21 [Arc Pro B50]
 	e215  Battlemage G21 [Intel Graphics]
 	e216  Battlemage G21 [Intel Graphics]
 	e220  Battlemage G31 [Intel Graphics]
 	e221  Battlemage G31 [Intel Graphics]
-	e222  Battlemage G31 [Intel Graphics]
-	e223  Battlemage G31 [Intel Graphics]
+	e222  Battlemage G31 [Arc Pro B65]
+	e223  Battlemage G31 [Arc Pro B70]
+	e300  Core Ultra Processors (Series 3) eSPI
+	e302  Core Ultra Processors (Series 3) eSPI
+	e31f  Core Ultra Processors (Series 3) eSPI
+	e320  Core Ultra Processors (Series 3) P2SB
+	e321  Core Ultra Processors (Series 3) PMC
+	e322  Core Ultra Processors (Series 3) SMBus
+	e323  Core Ultra Processors (Series 3) SPI (flash) Controller
+	e324  Core Ultra Processors (Series 3) Trace Hub
+	e325  Core Ultra Processors (Series 3) UART #0
+	e326  Core Ultra Processors (Series 3) UART #1
+	e327  Core Ultra Processors (Series 3) GSPI #0
+	e328  Core Ultra Processors (Series 3) HD Audio
+	e329  Core Ultra Processors (Series 3) HD Audio
+	e32a  Core Ultra Processors (Series 3) HD Audio
+	e32b  Core Ultra Processors (Series 3) HD Audio
+	e32c  Core Ultra Processors (Series 3) HD Audio
+	e32d  Core Ultra Processors (Series 3) HD Audio
+	e32e  Core Ultra Processors (Series 3) HD Audio
+	e32f  Core Ultra Processors (Series 3) HD Audio
+	e330  Core Ultra Processors (Series 3) GSPI #1
+	e331  Core Ultra Processors (Series 3) Type-C Subsystem xHCI
+	e332  Core Ultra Processors (Series 3) Type-C Subsystem xDCI
+	e333  Core Ultra Processors (Series 3) Thunderbolt DMA0
+	e334  Core Ultra Processors (Series 3) Thunderbolt DMA1
+	e337  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #24
+	e338  Core Ultra Processors (Series 3) PCIe Root Port #1
+	e339  Core Ultra Processors (Series 3) PCIe Root Port #2
+	e33a  Core Ultra Processors (Series 3) PCIe Root Port #3
+	e33b  Core Ultra Processors (Series 3) PCIe Root Port #4
+	e33c  Core Ultra Processors (Series 3) PCIe Root Port #5
+	e33d  Core Ultra Processors (Series 3) PCIe Root Port #6
+	e33e  Core Ultra Processors (Series 3) PCIe Root Port #7
+	e33f  Core Ultra Processors (Series 3) PCIe Root Port #8
+	e340  Core Ultra Processors (Series 3) CNVi Wi-Fi
+		8086 0094  Wi-Fi 6E AX211 160MHz
+	e341  Core Ultra Processors (Series 3) CNVi Wi-Fi
+	e342  Core Ultra Processors (Series 3) CNVi Wi-Fi
+	e343  Core Ultra Processors (Series 3) CNVi Wi-Fi
+	e344  Core Ultra Processors (Series 3) IEH #0
+	e345  Core Ultra Processors (Series 3) ISH
+	e346  Core Ultra Processors (Series 3) GSPI #2
+	e348  Core Ultra Processors (Series 3) THC #0 ID1
+	e349  Core Ultra Processors (Series 3) THC #0 ID2
+	e34a  Core Ultra Processors (Series 3) THC #1 ID1
+	e34b  Core Ultra Processors (Series 3) THC #1 ID2
+	e34c  Core Ultra Processors (Series 3) P2SB
+	e34d  Core Ultra Processors (Series 3) IEH #1
+	e34e  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #21
+	e34f  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #22
+	e350  Core Ultra Processors (Series 3) I2C #4
+	e351  Core Ultra Processors (Series 3) I2C #5
+	e352  Core Ultra Processors (Series 3) UART #2
+	e35c  Core Ultra Processors (Series 3) PCIe Root Port #10
+	e35d  Core Ultra Processors (Series 3) CSME HECI #1
+	e35e  Core Ultra Processors (Series 3) CSME HECI #2
+	e35f  Core Ultra Processors (Series 3) CSME HECI #3
+	e360  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #23
+	e361  Core Ultra Processors (Series 3) PCIe Root Port #9
+	e362  Core Ultra Processors (Series 3) CSME HECI #1
+	e363  Core Ultra Processors (Series 3) CSME HECI #2
+	e364  Core Ultra Processors (Series 3) CSME HECI #3
+	e365  Core Ultra Processors (Series 3) PCIe Root Port #11
+	e366  Core Ultra Processors (Series 3) PCIe Root Port #12
+	e367  Panther Lake PCI Express Root Port D3
+	e368  Panther Lake PCI Express Root Port D4
+	e369  Panther Lake PCI Express Root Port D5
+	e36a  Panther Lake PCI Express Root Port D6
+	e36b  Panther Lake PCI Express Root Port D7
+	e36c  Panther Lake PCI Express Root Port D8
+	e36f  Core Ultra Processors (Series 3) I3C #2
+	e370  Core Ultra Processors (Series 3) CSME HECI #1 (CSE)
+	e371  Core Ultra Processors (Series 3) CSME HECI #2 (CSE)
+	e372  Core Ultra Processors (Series 3) CSME IDE Redirection (IDE-R)
+	e373  Core Ultra Processors (Series 3) CSME Keyboard and Text (KT) Redirection
+	e374  Core Ultra Processors (Series 3) CSME HECI #3 (CSE)
+	e375  Core Ultra Processors (Series 3) CSME HECI #4 (CSE)
+	e376  Core Ultra Processors (Series 3) CNVi Bluetooth
+	e378  Core Ultra Processors (Series 3) I2C #0
+	e379  Core Ultra Processors (Series 3) I2C #1
+	e37a  Core Ultra Processors (Series 3) I2C #2
+	e37b  Core Ultra Processors (Series 3) I2C #3
+	e37c  Core Ultra Processors (Series 3) I3C #1
+	e37d  Core Ultra Processors (Series 3) Standalone xHCI Controller
+	e37e  Core Ultra Processors (Series 3) Standalone USB Device Controller
+	e37f  Core Ultra Processors (Series 3) Shared SRAM
+	e400  Core Ultra Processors (Series 3) eSPI
+	e41f  Core Ultra Processors (Series 3) eSPI
+	e420  Core Ultra Processors (Series 3) P2SB
+	e421  Core Ultra Processors (Series 3) PMC
+	e422  Core Ultra Processors (Series 3) SMBus
+	e423  Core Ultra Processors (Series 3) SPI (flash) Controller
+	e424  Core Ultra Processors (Series 3) Trace Hub
+	e425  Core Ultra Processors (Series 3) UART #0
+	e426  Core Ultra Processors (Series 3) UART #1
+	e427  Core Ultra Processors (Series 3) GSPI #0
+	e428  Core Ultra Processors (Series 3) HD Audio
+	e429  Core Ultra Processors (Series 3) HD Audio
+	e42a  Core Ultra Processors (Series 3) HD Audio
+	e42b  Core Ultra Processors (Series 3) HD Audio
+	e42c  Core Ultra Processors (Series 3) HD Audio
+	e42d  Core Ultra Processors (Series 3) HD Audio
+	e42e  Core Ultra Processors (Series 3) HD Audio
+	e42f  Core Ultra Processors (Series 3) HD Audio
+	e430  Core Ultra Processors (Series 3) GSPI #1
+	e431  Core Ultra Processors (Series 3) Type-C Subsystem xHCI
+	e432  Core Ultra Processors (Series 3) Type-C Subsystem xDCI
+	e433  Core Ultra Processors (Series 3) Thunderbolt DMA0
+	e434  Core Ultra Processors (Series 3) Thunderbolt DMA1
+	e437  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #24
+	e438  Core Ultra Processors (Series 3) PCIe Root Port #1
+	e439  Core Ultra Processors (Series 3) PCIe Root Port #2
+	e43a  Core Ultra Processors (Series 3) PCIe Root Port #3
+	e43b  Core Ultra Processors (Series 3) PCIe Root Port #4
+	e43c  Core Ultra Processors (Series 3) PCIe Root Port #5
+	e43d  Core Ultra Processors (Series 3) PCIe Root Port #6
+	e43e  Core Ultra Processors (Series 3) PCIe Root Port #7
+	e43f  Core Ultra Processors (Series 3) PCIe Root Port #8
+	e440  Core Ultra Processors (Series 3) CNVi Wi-Fi
+		8086 0114  Wi-Fi 7 BE211 320MHz
+	e441  Core Ultra Processors (Series 3) CNVi Wi-Fi
+	e442  Core Ultra Processors (Series 3) CNVi Wi-Fi
+	e443  Core Ultra Processors (Series 3) CNVi Wi-Fi
+	e444  Core Ultra Processors (Series 3) IEH #0
+	e445  Core Ultra Processors (Series 3) ISH
+	e446  Core Ultra Processors (Series 3) GSPI #2
+	e448  Core Ultra Processors (Series 3) THC #0 ID1
+	e449  Core Ultra Processors (Series 3) THC #0 ID2
+	e44a  Core Ultra Processors (Series 3) THC #1 ID1
+	e44b  Core Ultra Processors (Series 3) THC #1 ID2
+	e44c  Core Ultra Processors (Series 3) P2SB
+	e44d  Core Ultra Processors (Series 3) IEH #1
+	e44e  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #21
+	e44f  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #22
+	e450  Core Ultra Processors (Series 3) I2C #4
+	e451  Core Ultra Processors (Series 3) I2C #5
+	e452  Core Ultra Processors (Series 3) UART #2
+	e45c  Core Ultra Processors (Series 3) PCIe Root Port #10
+	e45d  Core Ultra Processors (Series 3) CSME HECI #1
+	e45e  Core Ultra Processors (Series 3) CSME HECI #2
+	e45f  Core Ultra Processors (Series 3) CSME HECI #3
+	e460  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #23
+	e461  Core Ultra Processors (Series 3) PCIe Root Port #9
+	e462  Core Ultra Processors (Series 3) CSME HECI #1
+	e463  Core Ultra Processors (Series 3) CSME HECI #2
+	e464  Core Ultra Processors (Series 3) CSME HECI #3
+	e46f  Core Ultra Processors (Series 3) I3C #2
+	e470  Core Ultra Processors (Series 3) CSME HECI #1 (CSE)
+	e471  Core Ultra Processors (Series 3) CSME HECI #2 (CSE)
+	e472  Core Ultra Processors (Series 3) CSME IDE Redirection (IDE-R)
+	e473  Core Ultra Processors (Series 3) CSME Keyboard and Text (KT) Redirection
+	e474  Core Ultra Processors (Series 3) CSME HECI #3 (CSE)
+	e475  Core Ultra Processors (Series 3) CSME HECI #4 (CSE)
+	e476  Core Ultra Processors (Series 3) CNVi Bluetooth
+	e478  Core Ultra Processors (Series 3) I2C #0
+	e479  Core Ultra Processors (Series 3) I2C #1
+	e47a  Core Ultra Processors (Series 3) I2C #2
+	e47b  Core Ultra Processors (Series 3) I2C #3
+	e47c  Core Ultra Processors (Series 3) I3C #1
+	e47d  Core Ultra Processors (Series 3) Standalone xHCI Controller
+	e47e  Core Ultra Processors (Series 3) Standalone USB Device Controller
+	e47f  Core Ultra Processors (Series 3) Shared SRAM
 	f1a5  SSD 600P Series
 		8086 390a  SSDPEKKW256G7 256GB
 	f1a6  SSD DC P4101/Pro 7600p/760p/E 6100p Series
@@ -39074,29 +41466,55 @@
 		8088 2000  Ethernet Network Adaptor RP2000 for 10GbE SFP+
 		8088 2300  Ethernet Network Adaptor RP2000-A03 for 10GbE SFP+
 		8088 2400  Ethernet Network Adaptor RP2000-A04 for 10GbE SFP+
+	5024  Ethernet Controller WX5025 Virtual Function for 25GbE SFP28
 	5025  Ethernet Controller WX5025 for 25GbE SFP28
 		8088 1000  Dual-Port Ethernet Network Adapter FF5025-DDATACXX
+	503f  Ethernet Controller WX5040 Virtual Function for 40GbE QSFP+
+# add new id
+	5040  Ethernet Controller WX5040 for 40GbE QSFP+
+# add new id
+		8088 1000  Dual-Port Ethernet Network Adapter FF5040-DDBTACXX
+	5124  Ethernet Controller WX5025AL Virtual Function for 25GbE SFP28
 	5125  Ethernet Controller WX5025AL for 25GbE SFP28
 		8088 3000  Dual-Port Ethernet Network Adapter FF5025-DDATAIXX
+	513f  Ethernet Controller WX5040AL Virtual Function for 40GbE QSFP+
+# add new id
+	5140  Ethernet Controller WX5040AL for 40GbE QSFP+
+# add new id
+		8088 3000  Dual-Port Ethernet Network Adapter FF5040-DDBTAIXX
 80ee  InnoTek Systemberatung GmbH
 	beef  VirtualBox Graphics Adapter
 	cafe  VirtualBox Guest Service
+8164  HippStor Technology Co., Ltd
+	1600  HP600 U.2 NVME SSD
 8322  Sodick America Corp.
 8384  SigmaTel
+8385  Suzhou Yige Technology Co., Ltd.
 8401  TRENDware International Inc.
+8412  Sharetronic Data Technology Co., Ltd.
 8510  Sietium Semiconductor Co., Ltd.
 	0201  GenBu02 Series GPU
 		8510 0001  GB2062-PUB-LPDDR
-		8510 0002  GB2062-PCIe-C0
+		8510 0002  GB2062-PCIe-C20
 		8510 0003  GB2062-PCIe-C41
 		8510 0004  GB2062-PCIe-HIEILP4
-		8510 0005  CQ2040-PCIe-C21
-		8510 0007  GB2062-PCIe-C40
-		8510 0008  CQ2040-MXM-M60
-		8510 0009  GB2062-PCIe-C20
-		8510 000b  GB2062-PCIe-HIEILP42
-		8510 000c  CQ2040-PUB
+		8510 0005  GB02-PCIe-C21
+		8510 0006  CQ2020-C2X Series
+		8510 0007  GB02-PCIe-C46-4HDMI
+		8510 0008  GB02-MXM-M60
+		8510 0009  GB02-PCIe-C46-4HDMI-2DP
+		8510 000a  GB02-MXM-M62-A-DP
+		8510 000b  GB02-PCIe-C42
+		8510 000c  GB02-PUB
+		8510 000d  GB02-PCIe-C46-6HDMI
+		8510 000e  GB02-MXM-M62-A-HDMI
+		8510 0010  GB02-MXM-M66-3HDMI-3DP
+		8510 0011  GB02-MXM-M66-2HDMI-4DP
+		8510 0012  GB02-PCIe-C25-HD
+		8510 0013  GB02-PCIe-C25-HH
+		8510 0014  GB2064-VPX-V40
 		8510 0201  GB2062-PUB-DDR
+	0301  GenBu03 Series GPU
 # nee ScaleMP
 8686  SAP
 	1010  vSMP Foundation controller [vSMP CTL]
@@ -39110,7 +41528,9 @@
 	1000  Ethernet Controller N10 Series for 10GbE or 40GbE (Dual-port)
 		4c52 3032  LRES3032PF Dual-port 10Gb Ethernet Server Adapter for OCP
 		8848 8410  Ethernet Network Adapter N10G-X2-DC for 10GbE SFP+ 2-port
+		8848 c410  Ethernet Network Adapter OCP3.0 N10G-X2-DCP for 10GbE SFP+ 2-port
 	1001  Ethernet Controller N400 Series for 1GbE (Dual-port)
+		8848 8000  Ethernet Network Adapter N400L-X4-DD for 1GbE SFP 2-port
 	1003  Ethernet Controller N400 Series for 10GbE (Single-port)
 		4c52 1050  LRES1050PF Single-port 10Gb Ethernet Network Adapter
 	1020  Ethernet Controller N10 Series for 10GbE (Quad-port)
@@ -39118,13 +41538,18 @@
 		4c52 1031  LRES1031PF Dual-port 10Gb Ethernet Server Adapter
 		4c52 3031  LRES3031PF Quad-port 10Gb Ethernet Server Adapter for OCP
 		8848 8451  Ethernet Network Adapter N10G-X4-QC for 10GbE SFP+ 4-port
+		8848 c451  Ethernet Network Adapter OCP3.0 N10G-X4-QCP for 10GbE SFP+ 4-port
 	1021  Ethernet Controller N400 Series for 1GbE (Quad-port)
 		4c52 1032  LRES1032PF Quad-port 1Gb Ethernet Network Adapter
 		4c52 1039  LRES1039PT Quad-port 1Gb Ethernet Network Adapter
+		8848 8041  Ethernet Network Adapter N400L-X4-QD for 1GbE SFP 4-port
 	1060  Ethernet Controller N10 Series for 1GbE or 10GbE (8-port)
 	1080  Ethernet Controller N10 Series Virtual Function
 	1081  Ethernet Controller N400 Series Virtual Function
 	1083  Ethernet Controller N400 Series Virtual Function
+	8208  Ethernet Controller N210M for 1GbE 1-port RJ45
+	8209  Ethernet Controller N210 Series Virtual Function
+	820a  Ethernet Controller N210L for 1GbE 1-port RJ45
 	8308  Ethernet Controller N500 Series for 1GbE (Quad-port, Copper RJ45)
 # NIC-ETH3M0T-3S-4P Quad-Port RJ45 Adapter for OCP 3.0
 		193d 1088  NIC-ETH3M0T-3S-4P
@@ -39134,6 +41559,19 @@
 	8318  Ethernet Controller N500 Series for 1GbE (Dual-port, Copper RJ45)
 		4c52 1049  LRES1049PT Dual-port 1Gb Ethernet Network Adapter
 		4c52 3043  LRES3043PT Dual-port 1Gb Ethernet Server Adapter for OCP
+	8500  Ethernet Controller N20 Series for 25GbE
+		8848 0800  Ethernet Network Adapter N20 for 25GbE SFP28
+		8848 8800  Ethernet Network Adapter N20 for RDMA 25GbE SFP28 2-port
+		8848 c800  Ethernet Network Adapter N20 for RDMA 25GbE SFP28 2-port OCP 3.0
+	8501  Ethernet Controller N20 Series for 100GbE
+		8848 8800  Ethernet Network Adapter N20 for RDMA 100GbE QSFP28 2-port
+	8502  Ethernet Controller N20 Series for 40GbE
+		8848 8800  Ethernet Network Adapter N20 for RDMA 40GbE QSFP+ 2-port
+	8503  Ethernet Controller N20 Series Virtual Function
+	8507  Ethernet Controller B-Series for 25GbE
+	8508  Ethernet Controller B-Series for 100GbE
+	8509  Ethernet Controller B-Series for 40GbE
+	850a  Ethernet Controller B-Series Virtual Function
 8866  T-Square Design Inc.
 8888  Silicon Magic
 	8504  AVMatrix VC42 4-port HDMI Capture
@@ -39830,7 +42268,10 @@ c0a9  Micron/Crucial Technology
 	5420  P3 NVMe PCIe SSD (DRAM-less)
 	5421  P3 Plus NVMe PCIe SSD (DRAM-less)
 	5426  P310 NVMe PCIe SSD (DRAM-less)
+	5427  P310 NVMe PCIe SSD (DRAM-less)
+	5428  T710 NVMe PCIe SSD
 	542b  T705 NVMe PCIe SSD
+	560a  P510 NVMe PCIe SSD (DRAM-less)
 	560b  E100 NVMe PCIe SSD (DRAM-less)
 c0de  Motorola
 c0fe  Motion Engineering, Inc.
@@ -39840,6 +42281,9 @@ ca02  I-TEK OptoElectronics Co., LTD.
 	0213  Vulcan-CXP Frame Grabber
 ca3b  Cambrionix Ltd.
 ca50  Varian Australia Pty Ltd
+cabc  Cambricon Technologies Corporation Limited
+	0270  MLU270-S4
+	0370  MLU370-S4
 cace  CACE Technologies, Inc.
 	0001  TurboCap Port A
 	0002  TurboCap Port B
@@ -39861,6 +42305,12 @@ cddd  Tyzx, Inc.
 	0200  DeepSea 2 High Speed Stereo Vision Frame Grabber
 cdfa  NextSilicon Ltd
 	0007  Maverick
+	0009  Maverick-2
+		cdfa 0900  Maverick-2 Single-Die PCIe Card
+		cdfa 0906  Maverick-2 Dual-Die OAM
+		cdfa 0bff  Maverick-2 Firmware Update
+# High-performance RISC-V CPU
+	0080  Arbel Test Chip
 ceba  KEBA AG
 cf86  Spectrum-4TOR
 	0276  Spectrum-4TOR in Flash Recovery Mode
@@ -39906,19 +42356,19 @@ d209  Ultimarc
 	1500  PAC Drive
 	15a2  SpinTrak
 	1601  AimTrak
-d20c  Chengdu BeiZhongWangXin Technology Co., Ltd.
-	5011  NE5000 Ethernet Controller
+d20c  Chengdu NorthLink Technology Co., Ltd.
+	5011  NE5025 Ethernet Controller
 		d20c e120  N5 Series 2-port 10GbE Network Adapter
 		d20c e140  N5 Series 4-port 10GbE Network Adapter
 		d20c e220  N5 Series 2-port 25GbE Network Adapter
-		d20c e221  N5S Series 2-port 25GbE Network Adapter
+		d20c e221  N5 Series 2-port 25GbE Network Adapter
 		d20c e22c  N5 Series 2-port 25GbE Network Adapter for OCP
-	6011  NE6000 Ethernet Controller
-		d20c a001  N6S Series Network Adapter
-		d20c e221  N6S Series 2-port 25GbE Network Adapter
-		d20c e281  N6S Series 8-port 25GbE Network Adapter
-		d20c e421  N6S Series 2-port 40GbE Network Adapter
-		d20c ea21  N6S Series 2-port 100GbE Network Adapter
+	6011  NE6100 Ethernet Controller
+		d20c a001  N6 Series Network Adapter
+		d20c e22e  N6 Series 2-port 25GbE Network Adapter
+		d20c e281  N6 Series 8-port 25GbE Network Adapter
+		d20c e421  N6 Series 2-port 40GbE Network Adapter
+		d20c ea21  N6 Series 2-port 100GbE Network Adapter
 d405  LeapIO
 	8200  LeapHBA
 	8201  LeapRAID
@@ -40185,6 +42635,11 @@ C 00  Unclassified device
 	05  Image coprocessor
 C 01  Mass storage controller
 	00  SCSI storage controller
+		00  Vendor specific
+		11  SCSI storage device (SOP target port using PQI)
+		12  SCSI controller (SOP target port using PQI)
+		13  SCSI storage device & controller (SOP target port using PQI)
+		21  SCSI storage device (SOP target port using NVMe)
 	01  IDE interface
 		00  ISA Compatibility mode-only controller
 		05  PCI native mode-only controller
@@ -40197,6 +42652,7 @@ C 01  Mass storage controller
 	02  Floppy disk controller
 	03  IPI bus controller
 	04  RAID bus controller
+		00  Vendor specific
 	05  ATA controller
 		20  ADMA single stepping
 		30  ADMA continuous operation
@@ -40209,12 +42665,14 @@ C 01  Mass storage controller
 	08  Non-Volatile memory controller
 		01  NVMHCI
 		02  NVM Express
+		03  NVM Express administrative controller
 	09  Universal Flash Storage controller
 		00  Vendor specific
 		01  UFSHCI
 	80  Mass storage controller
 C 02  Network controller
 	00  Ethernet controller
+		01  Ethernet Controller with IDPF Compliant Interface
 	01  Token ring network controller
 	02  FDDI network controller
 	03  ATM network controller
@@ -40236,13 +42694,15 @@ C 04  Multimedia controller
 	01  Multimedia audio controller
 	02  Computer telephony device
 	03  Audio device
+		00  HDA compatible
+		80  HDA compatible with vendor specific extensions
 	80  Multimedia controller
 C 05  Memory controller
 	00  RAM memory
 	01  FLASH memory
 	02  CXL
 		00  CXL Memory Device - vendor specific
-		10  CXL Memory Device (CXL 2.x)
+		10  CXL Memory Device (CXL 2.0 or later)
 	80  Memory controller
 C 06  Bridge
 	00  Host bridge
@@ -40358,6 +42818,7 @@ C 0c  Serial bus controller
 		02  BT (Block Transfer)
 	08  SERCOS interface
 	09  CANBUS
+	0a  MIPI I3C
 	80  Serial bus controller
 C 0d  Wireless controller
 	00  IRDA controller
@@ -40365,8 +42826,10 @@ C 0d  Wireless controller
 	10  RF controller
 	11  Bluetooth
 	12  Broadband
-	20  802.1a controller
-	21  802.1b controller
+	20  802.11a 5 GHz controller
+	21  802.11b 2.4 GHz controller
+	40  Cellular controller/modem
+	41  Cellular controller/modem plus Ethernet (802.11)
 	80  Wireless controller
 C 0e  Intelligent controller
 	00  I2O


### PR DESCRIPTION
Syncs `pkg/pciids/default_pci.ids` from Version 2025.07.11 (the last sync, PR #66) to the latest upstream `pci.ids` release (Version 2026.07.31, https://pci-ids.ucw.cz/v2.2/pci.ids). Generated with `make update-pcidb`.

Follows the exact pattern of the prior manual syncs (#66, #55, #52, #46, #42). The last sync landed a year ago today (2025-07-31); this catches up the ~3.3k additions / ~0.9k deletions that accumulated since.

## Why this matters: B300 (0x3182) missing → `UNKNOWN_DEVICE` resource name

The previous sync (2025.07.11) predates the NVIDIA B300 (Blackwell Ultra). The upstream `pci.ids` now contains the entry; this PR pulls it in:

```
3180  GB110 [Reserved Dev ID A]
3182  GB110 [B300 SXM6 AC]      <- added
31a1  GB110 [GB300 MaxQ]
31c0  GB110 [Reserved Dev ID B]
31c2  GB110 [GB300]
31c3  GB110 [GB300]
31fe  GB110
```

Without `0x3182` in this database, `pkg/nvpci` falls back to `UnknownDeviceString = "UNKNOWN_DEVICE"` (`nvpci.go:44`) when a B300 is enumerated. Downstream, the `nvidia-sandbox-device-plugin` (which vendors go-nvlib and uses it to name the Kata passthrough GPU resource) then advertises `nvidia.com/UNKNOWN_DEVICE=8` on B300 nodes instead of a model-specific name. The GPUs are fully functional for VFIO passthrough — only the resource *name* is wrong, so CC pods requesting `nvidia.com/pgpu: 8` (or a model-specific name) fail to schedule with `Insufficient nvidia.com/pgpu`.

### Verified on a production B300 node (2026-07-31)

```
$ lspci -nn -d 10de:3182 | head -2
12:00.0 3D controller [0302]: NVIDIA Corporation GB110 [B300 SXM6 AC] [10de:3182] (rev a1)
3a:00.0 3D controller [0302]: NVIDIA Corporation GB110 [B300 SXM6 AC] [10de:3182] (rev a1)
... (8x total)

$ kubectl get node am-b300-62 -o jsonpath='{.status.allocatable}' | jq 'with_entries(select(.key | test("nvidia")))'
{ "nvidia.com/UNKNOWN_DEVICE": "8" }   # <- should be a model-specific name

# sandbox-device-plugin logs:
# Found GPU UNKNOWN_DEVICE [3182] at 0000:12:00.0 (iommufd: vfio0)
# Registering device plugin "UNKNOWN_DEVICE" with 8 device(s)
```

For comparison, a B200 node (PCI `0x2901`, present in the 2025.07.11 pci.ids) advertises `nvidia.com/GB100_B200=8` — the lookup succeeds and the resource gets a proper name.

## Related issues

- **NVIDIA/gpu-operator#2231** — `nvidia-operator-validator fails to find device ID '3182' (B300)` (the validator's own lookup gap; a different code path but the same root cause)
- **NVIDIA/gpu-operator#2625** — added `0x318210DE` to the vGPU device-manager configmap (merged). Fixes the vGPU path but NOT the Kata sandbox-device-plugin path (which reads this `pci.ids`).
- **NVIDIA/gpu-operator#551** — the identical bug class in 2023 (`nvidia.com/2571` instead of a model name due to a stale pci.ids). Resolved by shipping a newer pci.ids — same fix pattern as this PR.
- **kata-containers/kata-containers#13270** — `Unable to run GPU workload on B200/B300 with multiple pgpu assigned (more than 3)` (open). A separate Kata/QEMU VFIO limitation on B200/B300, not the resource-naming bug — but linked for discoverability since both surface on B200/B300 CC nodes.

## Scope

Single file change: `pkg/pciids/default_pci.ids` (+3355 / −892). No Go code touched. The new file is the verbatim output of `make update-pcidb` (wget of the upstream pci.ids).

## Checklist

- [x] Generated with `make update-pcidb` (no manual edits)
- [x] No Go code changes
- [x] `0x3182  GB110 [B300 SXM6 AC]` confirmed present in the new file
- [x] Existing entries intact (H100 `0x2335`, H200 `0x2335`, B200 `0x2901`, HGX GB200 `0x2941` all still present)
- [x] File well-formed (42856 lines, terminates cleanly with the `C ff  Unassigned class` class entry)

Made with [Cursor](https://cursor.com)